### PR TITLE
Add ldconfig to installdeps.sh

### DIFF
--- a/installdeps.sh
+++ b/installdeps.sh
@@ -7,6 +7,7 @@ cd openssl-1.1.0f
 ./config
 make
 sudo make install
+sudo ldconfig
 cd ../
 
 wget http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-latest.tar.gz


### PR DESCRIPTION
A vanilla Ubuntu install requires `sudo ldconfig` after the openssl install or else one gets this error:

```./ckd: error while loading shared libraries: libcrypto.so.1.1: cannot open shared object file: No such file or directory```
