### PR TITLE
Added unconfirmed transaction tracking in the wallet

### DIFF
--- a/src/client/rpcserver.cpp
+++ b/src/client/rpcserver.cpp
@@ -226,16 +226,25 @@ Json::Value CryptoServer::listtransactions() {
 
     returning["transactions"] = Json::Value();
 
-    const std::set<CryptoKernel::Blockchain::transaction> transactions =
+    const std::tuple<std::set<CryptoKernel::Blockchain::transaction>, std::set<CryptoKernel::Blockchain::transaction>> transactions =
         wallet->listTransactions();
 
-    for(const auto& tx : transactions) {
+    auto unconfirmedOut = [&](const auto& tx, const bool unconfirmed) {  
         auto jsonTx = tx.toJson();
         for(auto& output : jsonTx["outputs"]) {
             CryptoKernel::Blockchain::output out(output);
             output["id"] = out.getId().toString();
+            output["unconfirmed"] = unconfirmed;
         }
-        returning["transactions"].append(jsonTx);
+        returning["transactions"].append(jsonTx); 
+    };   
+
+    for(const auto& tx : std::get<0>transactions) {
+        unconfirmedOut(tx, false);
+
+    }
+    for(const auto& tx : std::get<1>transactions) {
+        unconfirmedOut(tx, true);
     }
 
     return returning;

--- a/src/client/rpcserver.cpp
+++ b/src/client/rpcserver.cpp
@@ -239,11 +239,11 @@ Json::Value CryptoServer::listtransactions() {
         returning["transactions"].append(jsonTx); 
     };   
 
-    for(const auto& tx : std::get<0>transactions) {
+    for(const auto& tx : std::get<0>(transactions)) {
         unconfirmedOut(tx, false);
 
     }
-    for(const auto& tx : std::get<1>transactions) {
+    for(const auto& tx : std::get<1>(transactions)) {
         unconfirmedOut(tx, true);
     }
 

--- a/src/client/wallet.cpp
+++ b/src/client/wallet.cpp
@@ -719,9 +719,16 @@ std::tuple<std::set<CryptoKernel::Blockchain::transaction>, std::set<CryptoKerne
 
     std::tuple<std::set<CryptoKernel::Blockchain::transaction>, std::set<CryptoKernel::Blockchain::transaction>> returning;
 
+    const auto& unconfirmedTxs = blockchain->getUnconfirmedTransactions();
+
     for(it->SeekToFirst(); it->Valid(); it->Next()) {
         if (it->value()["unconfirmed"].asBool()) {
-           std::get<1>(returning).insert(tx); 
+            for (const CryptoKernel::Blockchain::transaction& tx : unconfirmedTxs) {
+                if (tx.getId().toString() == it->key()) {
+                   std::get<1>(returning).insert(tx); 
+                   break;
+                }
+            }
         }
         else {
             const CryptoKernel::Blockchain::transaction tx = blockchain->getTransaction(it->key());

--- a/src/client/wallet.cpp
+++ b/src/client/wallet.cpp
@@ -189,6 +189,36 @@ void CryptoKernel::Wallet::watchFunc() {
 
         bchainTx->abort();
         dbTx->commit();
+
+
+        // get the unconfirmed transactions
+        std::set<transaction> CryptoKernel::Blockchain::getUnconfirmedTransactions();
+        std::set<transaction> unconfirmedTxs;
+
+        // check to see if they are relevant
+        for(const CryptoKernel::Blockchain::transaction& tx : txs) {
+            // see if the public addresses match
+            CryptoKernel::Blockchain::output& out tx.getOutputs();
+            if(out.getData()["publicKey"].isString()) {
+            try {
+                Account acc = getAccountByKey(dbTx.get(), out.getData()["publicKey"].asString());
+                unconfirmedTxs.insert(tx);
+            } catch(const WalletException& e) {
+                continue;
+            }
+
+        }
+        // now we have all the unconfirmed txs
+
+
+        // process them if they are 
+
+        // flag something?
+
+        // check all the unconfirmed transactions in the account, see if they are confirmed now
+        //      if they are..... do soemthing
+        //      if they aren't   do nothing
+
     }
 }
 
@@ -226,7 +256,7 @@ void rewindTx(CryptoKernel::Blockchain::transaction& tx,
             utxos->put(walletTx, out.getId().toString(), newTxo.toJson());
         }
     }
-
+}
 
 
 void CryptoKernel::Wallet::rewindBlock(CryptoKernel::Storage::Transaction* walletTx,

--- a/src/client/wallet.cpp
+++ b/src/client/wallet.cpp
@@ -256,9 +256,7 @@ void CryptoKernel::Wallet::rewindBlock(CryptoKernel::Storage::Transaction* walle
     txs.insert(oldTip.getCoinbaseTx());
 
     for(const CryptoKernel::Blockchain::transaction& tx : txs) {
-        rewindTx(CryptoKernel::Blockchain::transaction& tx,
-                     CryptoKernel::Storage::Transaction* walletTx,
-                     CryptoKernel::Storage::Transaction* bchainTx);
+        rewindTx(tx, walletTx, bchainTx);
     }
 
     const CryptoKernel::Blockchain::dbBlock newTip = blockchain->getBlockDB(bchainTx,
@@ -318,7 +316,7 @@ void CryptoKernel::Wallet::clearDB() {
 }
 
 
-void CryptoKernel::Wallet::digestTx(CryptoKernel::Blockchain::transaction& tx,
+void CryptoKernel::Wallet::digestTx(const CryptoKernel::Blockchain::transaction& tx,
                  CryptoKernel::Storage::Transaction* walletTx,
                  CryptoKernel::Storage::Transaction* bchainTx,
                  const bool unconfirmed) {
@@ -385,10 +383,7 @@ void CryptoKernel::Wallet::digestBlock(CryptoKernel::Storage::Transaction* walle
     txs.insert(block.getCoinbaseTx());
 
     for(const CryptoKernel::Blockchain::transaction& tx : txs) {
-        digestTx(CryptoKernel::Blockchain::transaction& tx,
-                 CryptoKernel::Storage::Transaction* walletTx,
-                 CryptoKernel::Storage::Transaction* bchainTx,
-                 const CryptoKernel::Blockchain::block& block);
+        digestTx(tx, walletTx, bchainTx);
     }
 
     params->put(walletTx, "height",

--- a/src/client/wallet.cpp
+++ b/src/client/wallet.cpp
@@ -198,18 +198,22 @@ void CryptoKernel::Wallet::watchFunc() {
         // check to see if they are relevant
         for(const CryptoKernel::Blockchain::transaction& tx : txs) {
             // see if the public addresses match
+            
+            // look at outputs
             CryptoKernel::Blockchain::output& out tx.getOutputs();
             if(out.getData()["publicKey"].isString()) {
-            try {
-                Account acc = getAccountByKey(dbTx.get(), out.getData()["publicKey"].asString());
-                unconfirmedTxs.insert(tx);
-            } catch(const WalletException& e) {
-                continue;
+                try {
+                    Account acc = getAccountByKey(dbTx.get(), out.getData()["publicKey"].asString());
+                    unconfirmedTxs.insert(tx);
+                } catch(const WalletException& e) {
+                    continue;
+                }
             }
+
+            // look at inputs?
 
         }
         // now we have all the unconfirmed txs
-
 
         // process them if they are 
 

--- a/src/client/wallet.cpp
+++ b/src/client/wallet.cpp
@@ -223,7 +223,7 @@ void CryptoKernel::Wallet::watchFunc() {
             for (CryptoKernel::Blockchain::output out : tx.getOutputs()) {
                 Json::Value jsonTx = out.toJson();   
                 jsonTx["unconfirmed"] = true;
-                utxos->put(walletTx, out.getId().toString(), jsonTx);
+                utxos->put(dbTx.get(), out.getId().toString(), jsonTx);
             }
         }
     }

--- a/src/client/wallet.cpp
+++ b/src/client/wallet.cpp
@@ -200,7 +200,7 @@ void CryptoKernel::Wallet::watchFunc() {
     }
 }
 
-void CryptoKernel::Wallet::rewindTx(CryptoKernel::Blockchain::transaction& tx,
+void CryptoKernel::Wallet::rewindTx(const CryptoKernel::Blockchain::transaction& tx,
                      CryptoKernel::Storage::Transaction* walletTx,
                      CryptoKernel::Storage::Transaction* bchainTx) {
     const Json::Value txJson = transactions->get(walletTx, tx.getId().toString());

--- a/src/client/wallet.cpp
+++ b/src/client/wallet.cpp
@@ -192,8 +192,7 @@ void CryptoKernel::Wallet::watchFunc() {
 
 
         // get the unconfirmed transactions
-        std::set<CryptoKernel::Blockchain::transaction> CryptoKernel::Blockchain::getUnconfirmedTransactions();
-        std::set<CryptoKernel::Blockchain::transaction> unconfirmedTxs;
+        std::set<CryptoKernel::Blockchain::transaction> unconfirmedTxs = CryptoKernel::Blockchain::getUnconfirmedTransactions();
 
         // check to see if they are relevant
         for(const CryptoKernel::Blockchain::transaction& tx : unconfirmedTxs) {
@@ -220,9 +219,9 @@ void CryptoKernel::Wallet::watchFunc() {
         }
         // now we have all the unconfirmed txs
 
-        for(const CryptoKernel::Blockchain::transaction& tx : unconfirmedTxs) {
-            for (CryptoKernel::Blockchain::output& out : tx.getOutputs()) {
-                json::Value jsonTx = out.toJson();   
+        for(const CryptoKernel::Blockchain::transaction tx : unconfirmedTxs) {
+            for (CryptoKernel::Blockchain::output out : tx.getOutputs()) {
+                Json::Value jsonTx = out.toJson();   
                 jsonTx["unconfirmed"] = true;
                 utxos->put(walletTx, out.getId().toString(), jsonTx);
             }
@@ -362,7 +361,7 @@ void digestTx(CryptoKernel::Blockchain::transaction& tx,
 
             const CryptoKernel::Blockchain::output out = blockchain->getOutput(bchainTx,
                     inp.getOutputId().toString());
-            Account acc = getAccountByKey(walletTx, out.getData()["publicKey"].asString());
+               acc = getAccountByKey(walletTx, out.getData()["publicKey"].asString());
             acc.setBalance(acc.getBalance() - out.getValue());
             accounts->put(walletTx, acc.getName(), acc.toJson());
         }

--- a/src/client/wallet.cpp
+++ b/src/client/wallet.cpp
@@ -192,8 +192,8 @@ void CryptoKernel::Wallet::watchFunc() {
 
 
         // get the unconfirmed transactions
-        std::set<transaction> CryptoKernel::Blockchain::getUnconfirmedTransactions();
-        std::set<transaction> unconfirmedTxs;
+        std::set<CryptoKernel::Blockchain::transaction> CryptoKernel::Blockchain::getUnconfirmedTransactions();
+        std::set<CryptoKernel::Blockchain::transaction> unconfirmedTxs;
 
         // check to see if they are relevant
         for(const CryptoKernel::Blockchain::transaction& tx : txs) {
@@ -220,20 +220,12 @@ void CryptoKernel::Wallet::watchFunc() {
         }
         // now we have all the unconfirmed txs
 
-        // process them if they are 
-
-        // flag something?
         for(const CryptoKernel::Blockchain::transaction& tx : unconfirmedTxs) {
             Json::Value jsonTx = tx.toJson();   
             jsonTx["unconfirmed"] = true;
             utxos->put(dbTx.get(), tx.getOutputId().toString(), jsonTx);
 
         }
-
-        // check all the unconfirmed transactions in the account, see if they are confirmed now
-        //      if they are..... do soemthing
-        //      if they aren't   do nothing
-
     }
 }
 

--- a/src/client/wallet.h
+++ b/src/client/wallet.h
@@ -162,7 +162,7 @@ private:
     void digestTx(CryptoKernel::Blockchain::transaction& tx,
                      CryptoKernel::Storage::Transaction* walletTx,
                      CryptoKernel::Storage::Transaction* bchainTx,
-                     const CryptoKernel::Blockchain::block& block);
+                     const bool unconfirmed = false);
 
     std::recursive_mutex walletLock;
 

--- a/src/client/wallet.h
+++ b/src/client/wallet.h
@@ -151,7 +151,7 @@ private:
     void rewindBlock(CryptoKernel::Storage::Transaction* walletTx,
                      CryptoKernel::Storage::Transaction* bchainTx);
 
-    void rewindTx(CryptoKernel::Blockchain::transaction& tx,
+    void rewindTx(const CryptoKernel::Blockchain::transaction& tx,
                      CryptoKernel::Storage::Transaction* walletTx,
                      CryptoKernel::Storage::Transaction* bchainTx);
 
@@ -159,7 +159,7 @@ private:
                      CryptoKernel::Storage::Transaction* bchainTx,
                      const CryptoKernel::Blockchain::block& block);
 
-    void digestTx(CryptoKernel::Blockchain::transaction& tx,
+    void digestTx(const CryptoKernel::Blockchain::transaction& tx,
                      CryptoKernel::Storage::Transaction* walletTx,
                      CryptoKernel::Storage::Transaction* bchainTx,
                      const bool unconfirmed = false);

--- a/src/client/wallet.h
+++ b/src/client/wallet.h
@@ -150,7 +150,17 @@ private:
 
     void rewindBlock(CryptoKernel::Storage::Transaction* walletTx,
                      CryptoKernel::Storage::Transaction* bchainTx);
+
+    void rewindTx(CryptoKernel::Blockchain::transaction& tx,
+                     CryptoKernel::Storage::Transaction* walletTx,
+                     CryptoKernel::Storage::Transaction* bchainTx);
+
     void digestBlock(CryptoKernel::Storage::Transaction* walletTx,
+                     CryptoKernel::Storage::Transaction* bchainTx,
+                     const CryptoKernel::Blockchain::block& block);
+
+    void digestTx(CryptoKernel::Blockchain::transaction& tx,
+                     CryptoKernel::Storage::Transaction* walletTx,
                      CryptoKernel::Storage::Transaction* bchainTx,
                      const CryptoKernel::Blockchain::block& block);
 

--- a/src/client/wallet.h
+++ b/src/client/wallet.h
@@ -125,7 +125,7 @@ public:
 
     std::set<Account> listAccounts();
 
-    std::set<CryptoKernel::Blockchain::transaction> listTransactions();
+    std::tuple<std::set<CryptoKernel::Blockchain::transaction>, std::set<CryptoKernel::Blockchain::transaction>> listTransactions();
 
     CryptoKernel::Blockchain::transaction signTransaction(const
             CryptoKernel::Blockchain::transaction& tx, const std::string& password);


### PR DESCRIPTION
Modified wallet.h, wallet.cpp, and rpcserver.cpp
In the wallet.cpp watchFunc, I filter the unconfirmed transactions to the ones that correspond to the wallet. Those transactions can be viewed through the listTransactions rpc function. They contain a key value pair "unconfirmed" : true, to signify that they are not yet on the blockchain. 