### PR TITLE
Bug fixes to network and reorg code

### DIFF
--- a/src/kernel/blockchain.cpp
+++ b/src/kernel/blockchain.cpp
@@ -836,7 +836,7 @@ void CryptoKernel::Blockchain::reverseBlock(Storage::Transaction* dbTransaction)
 
 	for(const auto& tx : replayTxs) {
 		if(!std::get<0>(submitTransaction(dbTransaction, tx))) {
-            log->printf(LOG_LEVEL_ERR,
+            log->printf(LOG_LEVEL_WARN,
                         "Blockchain::reverseBlock(): previously moved transaction is now invalid");
         }
 	}

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -328,8 +328,11 @@ void CryptoKernel::Network::networkFunc() {
                         log->printf(LOG_LEVEL_INFO,
                                     "Network(): Downloading blocks " + std::to_string(currentHeight + 1) + " to " +
                                     std::to_string(currentHeight + 6));
+
+                        auto nBlocks = 0;
                         try {
                             const auto newBlocks = it->second->peer->getBlocks(currentHeight + 1, currentHeight + 6);
+                            nBlocks = newBlocks.size();
                             blocks.insert(blocks.begin(), newBlocks.rbegin(), newBlocks.rend());
                         } catch(Peer::NetworkError& e) {
                             log->printf(LOG_LEVEL_WARN,
@@ -338,7 +341,7 @@ void CryptoKernel::Network::networkFunc() {
                             break;
                         }
 
-                        currentHeight = std::min(currentHeight + 5, bestHeight);
+                        currentHeight = std::min(currentHeight + nBlocks, bestHeight);
                     }
 
                     if(blockProcessor) {


### PR DESCRIPTION
- Transaction resubmission failure during block rewind is non-fatal, the transactions are stored in the candidate table anyway and failure is not a big deal (there is probably a conflict in the mempool). It's a warning instead now.
- Fix bug where outputs were not being removed from the stxos table during block rewind.
- Network code should only move currentHeight counter according to the number of blocks actually received.
- Ensure bestHeight is not below our own height.