### PR TITLE
Add flush to each line logged

### DIFF
--- a/src/kernel/log.cpp
+++ b/src/kernel/log.cpp
@@ -69,7 +69,7 @@ bool CryptoKernel::Log::printf(int loglevel, std::string message) {
     stagingstream << message << "\n";
 
     if(fPrintToConsole) {
-        std::cout << stagingstream.str();
+        std::cout << stagingstream.str() << std::flush;
     }
 
     logfilemutex.lock();


### PR DESCRIPTION
When running in a service manager which captures STDOUT, output is batched until the buffer fills therefore preventing realtime capture. This flushes on each write.