### PR TITLE
FastWriter used to add a newline to output, new code should do the same

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ LYRAOBJS = $(LYRASRC:.c=.c.o)
 CLIENTSRC = src/client/main.cpp src/client/rpcserver.cpp src/client/wallet.cpp src/client/httpserver.cpp src/client/multicoin.cpp
 CLIENTOBJS = $(CLIENTSRC:.cpp=.cpp.o)
 
-TESTSRC = tests/CryptoKernelTestRunner.cpp tests/CryptoTests.cpp tests/MathTests.cpp tests/MerkletreeTests.cpp tests/StorageTests.cpp tests/LogTests.cpp
+TESTSRC = tests/CryptoKernelTestRunner.cpp tests/CryptoTests.cpp tests/MathTests.cpp tests/MerkletreeTests.cpp tests/StorageTests.cpp tests/LogTests.cpp tests/BlockchainTypesTests.cpp
 TESTOBJS = $(TESTSRC:.cpp=.cpp.o)
 
 CXXFLAGS = $(KERNELCXXFLAGS) $(PLATFORMCXXFLAGS) -I$(LUA_INCDIR)

--- a/src/kernel/storage.cpp
+++ b/src/kernel/storage.cpp
@@ -82,7 +82,7 @@ std::string CryptoKernel::Storage::toString(const Json::Value& json, const bool 
     }
     writer.reset(builder.newStreamWriter());
     writer->write(json, &buf);
-    return buf.str();
+    return buf.str() + "\n";
 }
 
 bool CryptoKernel::Storage::destroy(const std::string& filename) {

--- a/tests/BlockchainTypesTests.cpp
+++ b/tests/BlockchainTypesTests.cpp
@@ -1,0 +1,26 @@
+#include "BlockchainTypesTests.h"
+
+#include "blockchain.h"
+
+CPPUNIT_TEST_SUITE_REGISTRATION(BlockchainTypesTest);
+
+BlockchainTypesTest::BlockchainTypesTest() {}
+
+BlockchainTypesTest::~BlockchainTypesTest() {}
+
+void BlockchainTypesTest::setUp() {}
+
+void BlockchainTypesTest::tearDown() {}
+
+/**
+* Tests that outputs have the correct ID
+*/
+void BlockchainTypesTest::testOutputId() {
+    Json::Value data;
+    data["publicKey"] = "BMoEeFbdyC8blWvlklSJ2oKRjEJfcq08+HZkmQW1ICJpC7nebygMt5AXhXDiwHuEF4KlHuJBwNGatpKifhoqp4s=";
+
+    CryptoKernel::Blockchain::output out(8081988463, 4062896946, data);
+
+    CPPUNIT_ASSERT_EQUAL(std::string("ff8840289b59187d16521ddde6b19de1c1b8994220a4dbb112f5978b34605b17"),
+    out.getId().toString());
+}

--- a/tests/BlockchainTypesTests.h
+++ b/tests/BlockchainTypesTests.h
@@ -1,0 +1,24 @@
+#ifndef CRYPTOTEST_H
+#define CRYPTOTEST_H
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class BlockchainTypesTest : public CPPUNIT_NS::TestFixture {
+    CPPUNIT_TEST_SUITE(BlockchainTypesTest);
+
+    CPPUNIT_TEST(testOutputId);
+
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    BlockchainTypesTest();
+    virtual ~BlockchainTypesTest();
+    void setUp();
+    void tearDown();
+
+private:
+    void testOutputId();
+
+};
+
+#endif


### PR DESCRIPTION
When we replaced FastWriter with StreamWriterBuilder the output format changed (neglecting a trailing newline) and thus blockchain type IDs changed. Since that's consensus critical the new toString code needs to produce the same format string. Add a unit test to catch regressions.