### PR TITLE
Install issue

### DIFF
--- a/installdeps.sh
+++ b/installdeps.sh
@@ -14,7 +14,7 @@ cd ../
 
 wget http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-latest.tar.gz
 tar -xvzf libmicrohttpd-latest.tar.gz
-
+rm libmicrohttpd-latest.tar.gz
 cd libmicrohttpd*
 ./configure
 make

--- a/installdeps.sh
+++ b/installdeps.sh
@@ -14,6 +14,7 @@ cd ../
 
 wget http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-latest.tar.gz
 tar -xvzf libmicrohttpd-latest.tar.gz
+
 cd libmicrohttpd*
 ./configure
 make


### PR DESCRIPTION
When i run installdeps.sh on Ubuntu 18.04, the line that does `cd libmicrohttpd*` fails with the error `./installdeps.sh: line 18: cd: too many arguments`

For some reason, it matches the .tgz also for `cd`. Added a statement removing the tgz after unpacking fixes this issue.