### PR TITLE
Fixes installdeps issue on Ubuntu 18.04

### DIFF
--- a/installdeps.sh
+++ b/installdeps.sh
@@ -14,6 +14,7 @@ cd ../
 
 wget http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-latest.tar.gz
 tar -xvzf libmicrohttpd-latest.tar.gz
+rm libmicrohttpd-latest.tar.gz
 cd libmicrohttpd*
 ./configure
 make


### PR DESCRIPTION
When running `installdeps.sh` on Ubuntu 18.04, the line that does `cd libmicrohttpd*` will fail with 

```
./installdeps.sh: line 18: cd: too many arguments
```

Removing the .tgz after unpacking it fixes this issue for me.