### PR TITLE
add creationTx flag to outputs

### DIFF
--- a/src/client/rpcserver.cpp
+++ b/src/client/rpcserver.cpp
@@ -149,7 +149,7 @@ Json::Value CryptoServer::listunspentoutputs(const std::string& account) {
     try {
         CryptoKernel::Wallet::Account acc = wallet->getAccountByName(account);
 
-        std::set<CryptoKernel::Blockchain::output> utxos;
+        std::set<CryptoKernel::Blockchain::dbOutput> utxos;
 
         for(const auto& addr : acc.getKeys()) {
             const auto unspent = blockchain->getUnspentOutputs(addr.pubKey);
@@ -158,9 +158,9 @@ Json::Value CryptoServer::listunspentoutputs(const std::string& account) {
 
         Json::Value returning;
 
-        for(const CryptoKernel::Blockchain::output& output : utxos) {
-            Json::Value out = output.toJson();
-            out["id"] = output.getId().toString();
+        for(const CryptoKernel::Blockchain::dbOutput& dbOutput : utxos) {
+            Json::Value out = dbOutput.toJson();
+            out["id"] = dbOutput.getId().toString();
             returning["outputs"].append(out);
         }
 
@@ -252,7 +252,7 @@ Json::Value CryptoServer::listtransactions() {
         jsonTx["id"] = tx.getId().toString();
         returning["transactions"]["unconfirmed"].append(jsonTx);
     }
-    
+
     return returning;
 }
 

--- a/src/kernel/blockchain.cpp
+++ b/src/kernel/blockchain.cpp
@@ -719,12 +719,12 @@ CryptoKernel::Blockchain::block CryptoKernel::Blockchain::generateVerifyingBlock
     return returning;
 }
 
-std::set<CryptoKernel::Blockchain::output> CryptoKernel::Blockchain::getUnspentOutputs(
+std::set<CryptoKernel::Blockchain::dbOutput> CryptoKernel::Blockchain::getUnspentOutputs(
     const std::string& publicKey) {
     std::lock_guard<std::recursive_mutex> lock(chainLock);
     std::unique_ptr<Storage::Transaction> dbTx(blockdb->begin());
 
-    std::set<output> returning;
+    std::set<dbOutput> returning;
 
     const auto unspent = utxos->get(dbTx.get(), publicKey, 0);
 
@@ -735,12 +735,12 @@ std::set<CryptoKernel::Blockchain::output> CryptoKernel::Blockchain::getUnspentO
     return returning;
 }
 
-std::set<CryptoKernel::Blockchain::output> CryptoKernel::Blockchain::getSpentOutputs(
+std::set<CryptoKernel::Blockchain::dbOutput> CryptoKernel::Blockchain::getSpentOutputs(
     const std::string& publicKey) {
     std::lock_guard<std::recursive_mutex> lock(chainLock);
     std::unique_ptr<Storage::Transaction> dbTx(blockdb->begin());
 
-    std::set<output> returning;
+    std::set<dbOutput> returning;
 
     const auto spent = stxos->get(dbTx.get(), publicKey, 0);
 

--- a/src/kernel/blockchain.h
+++ b/src/kernel/blockchain.h
@@ -336,9 +336,9 @@ public:
 
     input getInput(Storage::Transaction* dbTx, const std::string& id);
 
-    std::set<output> getUnspentOutputs(const std::string& publicKey);
+    std::set<dbOutput> getUnspentOutputs(const std::string& publicKey);
 
-    std::set<output> getSpentOutputs(const std::string& publicKey);
+    std::set<dbOutput> getSpentOutputs(const std::string& publicKey);
 
     std::set<transaction> getUnconfirmedTransactions();
 


### PR DESCRIPTION
This PR adds the the "creationTx" flag to outputs so that outputs have a back pointer to what transaction derived it.