### PR TITLE
Implement a read-only storage transaction and cache peerInfo for RPC

### DIFF
--- a/src/kernel/blockchain.cpp
+++ b/src/kernel/blockchain.cpp
@@ -47,7 +47,7 @@ CryptoKernel::Blockchain::Blockchain(CryptoKernel::Log* GlobalLog,
 
 bool CryptoKernel::Blockchain::loadChain(CryptoKernel::Consensus* consensus,
                                          const std::string& genesisBlockFile) {
-    std::lock_guard<std::recursive_mutex> lock(chainLock);
+    //std::lock_guard<std::recursive_mutex> lock(chainLock);
     this->consensus = consensus;
     std::unique_ptr<Storage::Transaction> dbTransaction(blockdb->begin());
     const bool tipExists = blocks->get(dbTransaction.get(), "tip").isObject();
@@ -104,9 +104,9 @@ CryptoKernel::Blockchain::~Blockchain() {
 
 std::set<CryptoKernel::Blockchain::transaction>
 CryptoKernel::Blockchain::getUnconfirmedTransactions() {
-    chainLock.lock();
+    //chainLock.lock();
     const std::set<CryptoKernel::Blockchain::transaction> returning = unconfirmedTransactions.getTransactions();
-    chainLock.unlock();
+    //chainLock.unlock();
 
     return returning;
 }
@@ -129,8 +129,9 @@ CryptoKernel::Blockchain::dbBlock CryptoKernel::Blockchain::getBlockDB(
 
 CryptoKernel::Blockchain::dbBlock CryptoKernel::Blockchain::getBlockDB(
     const std::string& id) {
-    std::lock_guard<std::recursive_mutex> lock(chainLock);
-    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());
+    /*std::lock_guard<std::recursive_mutex> lock(chainLock);
+    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());*/
+    std::unique_ptr<Storage::Transaction> tx(blockdb->beginReadOnly());
 
     return getBlockDB(tx.get(), id);
 }
@@ -178,29 +179,33 @@ CryptoKernel::Blockchain::dbBlock CryptoKernel::Blockchain::getBlockByHeightDB(
 
 CryptoKernel::Blockchain::transaction CryptoKernel::Blockchain::getTransaction(
     const std::string& id) {
-    std::lock_guard<std::recursive_mutex> lock(chainLock);
-    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());
+    /*std::lock_guard<std::recursive_mutex> lock(chainLock);
+    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());*/
+    std::unique_ptr<Storage::Transaction> tx(blockdb->beginReadOnly());
     return getTransaction(tx.get(), id);
 }
 
 CryptoKernel::Blockchain::block CryptoKernel::Blockchain::getBlock(
     const std::string& id) {
-    std::lock_guard<std::recursive_mutex> lock(chainLock);
-    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());
+    /*std::lock_guard<std::recursive_mutex> lock(chainLock);
+    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());*/
+    std::unique_ptr<Storage::Transaction> tx(blockdb->beginReadOnly());
     return getBlock(tx.get(), id);
 }
 
 CryptoKernel::Blockchain::block CryptoKernel::Blockchain::getBlockByHeight(
     const uint64_t height) {
-    std::lock_guard<std::recursive_mutex> lock(chainLock);
-    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());
+    /*std::lock_guard<std::recursive_mutex> lock(chainLock);
+    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());*/
+    std::unique_ptr<Storage::Transaction> tx(blockdb->beginReadOnly());
     return getBlockByHeight(tx.get(), height);
 }
 
 CryptoKernel::Blockchain::output CryptoKernel::Blockchain::getOutput(
     const std::string& id) {
-    std::lock_guard<std::recursive_mutex> lock(chainLock);
-    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());
+    /*std::lock_guard<std::recursive_mutex> lock(chainLock);
+    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());*/
+    std::unique_ptr<Storage::Transaction> tx(blockdb->beginReadOnly());
     return getOutput(tx.get(), id);
 }
 
@@ -343,7 +348,7 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::verifyTransaction(Storage::Tran
 }
 
 std::tuple<bool, bool> CryptoKernel::Blockchain::submitTransaction(const transaction& tx) {
-    std::lock_guard<std::recursive_mutex> lock(chainLock);
+    //std::lock_guard<std::recursive_mutex> lock(chainLock);
     std::unique_ptr<Storage::Transaction> dbTx(blockdb->begin());
     const auto result = submitTransaction(dbTx.get(), tx);
     if(std::get<0>(result)) {
@@ -353,7 +358,7 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::submitTransaction(const transac
 }
 
 std::tuple<bool, bool> CryptoKernel::Blockchain::submitBlock(const block& newBlock, bool genesisBlock) {
-    std::lock_guard<std::recursive_mutex> lock(chainLock);
+    //std::lock_guard<std::recursive_mutex> lock(chainLock);
     std::unique_ptr<Storage::Transaction> dbTx(blockdb->begin());
     const auto result = submitBlock(dbTx.get(), newBlock, genesisBlock);
     if(std::get<0>(result)) {
@@ -364,7 +369,7 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::submitBlock(const block& newBlo
 
 std::tuple<bool, bool> CryptoKernel::Blockchain::submitTransaction(Storage::Transaction* dbTx,
         const transaction& tx) {
-    std::lock_guard<std::recursive_mutex> lock(chainLock);
+    //std::lock_guard<std::recursive_mutex> lock(chainLock);
 	const auto verifyResult = verifyTransaction(dbTx, tx);
     if(std::get<0>(verifyResult)) {
         if(consensus->submitTransaction(dbTx, tx)) {
@@ -391,7 +396,7 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::submitTransaction(Storage::Tran
 
 std::tuple<bool, bool> CryptoKernel::Blockchain::submitBlock(Storage::Transaction* dbTx,
         const block& Block, bool genesisBlock) {
-    std::lock_guard<std::recursive_mutex> lock(chainLock);
+    //std::lock_guard<std::recursive_mutex> lock(chainLock);
 
     block newBlock = Block;
 
@@ -689,8 +694,9 @@ uint64_t CryptoKernel::Blockchain::calculateTransactionFee(Storage::Transaction*
 
 CryptoKernel::Blockchain::block CryptoKernel::Blockchain::generateVerifyingBlock(
     const std::string& publicKey) {
-    std::lock_guard<std::recursive_mutex> lock(chainLock);
-    std::unique_ptr<Storage::Transaction> dbTx(blockdb->begin());
+    /*std::lock_guard<std::recursive_mutex> lock(chainLock);
+    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());*/
+    std::unique_ptr<Storage::Transaction> dbTx(blockdb->beginReadOnly());
 
     const std::set<transaction> blockTransactions = getUnconfirmedTransactions();
 
@@ -741,8 +747,9 @@ CryptoKernel::Blockchain::block CryptoKernel::Blockchain::generateVerifyingBlock
 
 std::set<CryptoKernel::Blockchain::dbOutput> CryptoKernel::Blockchain::getUnspentOutputs(
     const std::string& publicKey) {
-    std::lock_guard<std::recursive_mutex> lock(chainLock);
-    std::unique_ptr<Storage::Transaction> dbTx(blockdb->begin());
+    /*std::lock_guard<std::recursive_mutex> lock(chainLock);
+    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());*/
+    std::unique_ptr<Storage::Transaction> dbTx(blockdb->beginReadOnly());
 
     std::set<dbOutput> returning;
 
@@ -757,8 +764,9 @@ std::set<CryptoKernel::Blockchain::dbOutput> CryptoKernel::Blockchain::getUnspen
 
 std::set<CryptoKernel::Blockchain::dbOutput> CryptoKernel::Blockchain::getSpentOutputs(
     const std::string& publicKey) {
-    std::lock_guard<std::recursive_mutex> lock(chainLock);
-    std::unique_ptr<Storage::Transaction> dbTx(blockdb->begin());
+    /*std::lock_guard<std::recursive_mutex> lock(chainLock);
+    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());*/
+    std::unique_ptr<Storage::Transaction> dbTx(blockdb->beginReadOnly());
 
     std::set<dbOutput> returning;
 
@@ -860,7 +868,7 @@ void CryptoKernel::Blockchain::reverseBlock(Storage::Transaction* dbTransaction)
 
 CryptoKernel::Blockchain::dbTransaction CryptoKernel::Blockchain::getTransactionDB(
     Storage::Transaction* transaction, const std::string& id) {
-    std::lock_guard<std::recursive_mutex> lock(chainLock);
+    //std::lock_guard<std::recursive_mutex> lock(chainLock);
     const Json::Value jsonTx = transactions->get(transaction, id);
     if(!jsonTx.isObject()) {
         throw NotFoundException("Transaction " + id);
@@ -871,7 +879,7 @@ CryptoKernel::Blockchain::dbTransaction CryptoKernel::Blockchain::getTransaction
 
 CryptoKernel::Blockchain::transaction CryptoKernel::Blockchain::getTransaction(
     Storage::Transaction* transaction, const std::string& id) {
-    std::lock_guard<std::recursive_mutex> lock(chainLock);
+    //std::lock_guard<std::recursive_mutex> lock(chainLock);
     const Json::Value jsonTx = transactions->get(transaction, id);
     if(!jsonTx.isObject()) {
         throw NotFoundException("Transaction " + id);
@@ -899,8 +907,9 @@ void CryptoKernel::Blockchain::emptyDB() {
 }
 
 CryptoKernel::Storage::Transaction* CryptoKernel::Blockchain::getTxHandle() {
-    chainLock.lock();
-    Storage::Transaction* dbTx = blockdb->begin(chainLock);
+    //chainLock.lock();
+    //Storage::Transaction* dbTx = blockdb->begin(chainLock);
+    Storage::Transaction* dbTx = blockdb->begin();
     return dbTx;
 }
 

--- a/src/kernel/blockchain.cpp
+++ b/src/kernel/blockchain.cpp
@@ -914,7 +914,7 @@ void CryptoKernel::Blockchain::emptyDB() {
 CryptoKernel::Storage::Transaction* CryptoKernel::Blockchain::getTxHandle() {
     //chainLock.lock();
     //Storage::Transaction* dbTx = blockdb->begin(chainLock);
-    Storage::Transaction* dbTx = blockdb->begin();
+    Storage::Transaction* dbTx = blockdb->beginReadOnly();
     return dbTx;
 }
 

--- a/src/kernel/blockchain.cpp
+++ b/src/kernel/blockchain.cpp
@@ -47,7 +47,6 @@ CryptoKernel::Blockchain::Blockchain(CryptoKernel::Log* GlobalLog,
 
 bool CryptoKernel::Blockchain::loadChain(CryptoKernel::Consensus* consensus,
                                          const std::string& genesisBlockFile) {
-    //std::lock_guard<std::recursive_mutex> lock(chainLock);
     this->consensus = consensus;
     std::unique_ptr<Storage::Transaction> dbTransaction(blockdb->begin());
     const bool tipExists = blocks->get(dbTransaction.get(), "tip").isObject();
@@ -129,8 +128,6 @@ CryptoKernel::Blockchain::dbBlock CryptoKernel::Blockchain::getBlockDB(
 
 CryptoKernel::Blockchain::dbBlock CryptoKernel::Blockchain::getBlockDB(
     const std::string& id) {
-    /*std::lock_guard<std::recursive_mutex> lock(chainLock);
-    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());*/
     std::unique_ptr<Storage::Transaction> tx(blockdb->beginReadOnly());
 
     return getBlockDB(tx.get(), id);
@@ -179,32 +176,24 @@ CryptoKernel::Blockchain::dbBlock CryptoKernel::Blockchain::getBlockByHeightDB(
 
 CryptoKernel::Blockchain::transaction CryptoKernel::Blockchain::getTransaction(
     const std::string& id) {
-    /*std::lock_guard<std::recursive_mutex> lock(chainLock);
-    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());*/
     std::unique_ptr<Storage::Transaction> tx(blockdb->beginReadOnly());
     return getTransaction(tx.get(), id);
 }
 
 CryptoKernel::Blockchain::block CryptoKernel::Blockchain::getBlock(
     const std::string& id) {
-    /*std::lock_guard<std::recursive_mutex> lock(chainLock);
-    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());*/
     std::unique_ptr<Storage::Transaction> tx(blockdb->beginReadOnly());
     return getBlock(tx.get(), id);
 }
 
 CryptoKernel::Blockchain::block CryptoKernel::Blockchain::getBlockByHeight(
     const uint64_t height) {
-    /*std::lock_guard<std::recursive_mutex> lock(chainLock);
-    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());*/
     std::unique_ptr<Storage::Transaction> tx(blockdb->beginReadOnly());
     return getBlockByHeight(tx.get(), height);
 }
 
 CryptoKernel::Blockchain::output CryptoKernel::Blockchain::getOutput(
     const std::string& id) {
-    /*std::lock_guard<std::recursive_mutex> lock(chainLock);
-    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());*/
     std::unique_ptr<Storage::Transaction> tx(blockdb->beginReadOnly());
     return getOutput(tx.get(), id);
 }
@@ -348,7 +337,6 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::verifyTransaction(Storage::Tran
 }
 
 std::tuple<bool, bool> CryptoKernel::Blockchain::submitTransaction(const transaction& tx) {
-    //std::lock_guard<std::recursive_mutex> lock(chainLock);
     std::unique_ptr<Storage::Transaction> dbTx(blockdb->begin());
     const auto result = submitTransaction(dbTx.get(), tx);
     if(std::get<0>(result)) {
@@ -358,7 +346,6 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::submitTransaction(const transac
 }
 
 std::tuple<bool, bool> CryptoKernel::Blockchain::submitBlock(const block& newBlock, bool genesisBlock) {
-    //std::lock_guard<std::recursive_mutex> lock(chainLock);
     std::unique_ptr<Storage::Transaction> dbTx(blockdb->begin());
     const auto result = submitBlock(dbTx.get(), newBlock, genesisBlock);
     if(std::get<0>(result)) {
@@ -369,7 +356,6 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::submitBlock(const block& newBlo
 
 std::tuple<bool, bool> CryptoKernel::Blockchain::submitTransaction(Storage::Transaction* dbTx,
         const transaction& tx) {
-    //std::lock_guard<std::recursive_mutex> lock(chainLock);
 	const auto verifyResult = verifyTransaction(dbTx, tx);
     if(std::get<0>(verifyResult)) {
         if(consensus->submitTransaction(dbTx, tx)) {
@@ -397,8 +383,6 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::submitTransaction(Storage::Tran
 
 std::tuple<bool, bool> CryptoKernel::Blockchain::submitBlock(Storage::Transaction* dbTx,
         const block& Block, bool genesisBlock) {
-    //std::lock_guard<std::recursive_mutex> lock(chainLock);
-
     block newBlock = Block;
 
     const std::string idAsString = newBlock.getId().toString();
@@ -697,8 +681,6 @@ uint64_t CryptoKernel::Blockchain::calculateTransactionFee(Storage::Transaction*
 
 CryptoKernel::Blockchain::block CryptoKernel::Blockchain::generateVerifyingBlock(
     const std::string& publicKey) {
-    /*std::lock_guard<std::recursive_mutex> lock(chainLock);
-    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());*/
     std::unique_ptr<Storage::Transaction> dbTx(blockdb->beginReadOnly());
 
     const std::set<transaction> blockTransactions = getUnconfirmedTransactions();
@@ -750,8 +732,6 @@ CryptoKernel::Blockchain::block CryptoKernel::Blockchain::generateVerifyingBlock
 
 std::set<CryptoKernel::Blockchain::dbOutput> CryptoKernel::Blockchain::getUnspentOutputs(
     const std::string& publicKey) {
-    /*std::lock_guard<std::recursive_mutex> lock(chainLock);
-    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());*/
     std::unique_ptr<Storage::Transaction> dbTx(blockdb->beginReadOnly());
 
     std::set<dbOutput> returning;
@@ -767,8 +747,6 @@ std::set<CryptoKernel::Blockchain::dbOutput> CryptoKernel::Blockchain::getUnspen
 
 std::set<CryptoKernel::Blockchain::dbOutput> CryptoKernel::Blockchain::getSpentOutputs(
     const std::string& publicKey) {
-    /*std::lock_guard<std::recursive_mutex> lock(chainLock);
-    std::unique_ptr<Storage::Transaction> tx(blockdb->begin());*/
     std::unique_ptr<Storage::Transaction> dbTx(blockdb->beginReadOnly());
 
     std::set<dbOutput> returning;
@@ -873,7 +851,6 @@ void CryptoKernel::Blockchain::reverseBlock(Storage::Transaction* dbTransaction)
 
 CryptoKernel::Blockchain::dbTransaction CryptoKernel::Blockchain::getTransactionDB(
     Storage::Transaction* transaction, const std::string& id) {
-    //std::lock_guard<std::recursive_mutex> lock(chainLock);
     const Json::Value jsonTx = transactions->get(transaction, id);
     if(!jsonTx.isObject()) {
         throw NotFoundException("Transaction " + id);
@@ -884,7 +861,6 @@ CryptoKernel::Blockchain::dbTransaction CryptoKernel::Blockchain::getTransaction
 
 CryptoKernel::Blockchain::transaction CryptoKernel::Blockchain::getTransaction(
     Storage::Transaction* transaction, const std::string& id) {
-    //std::lock_guard<std::recursive_mutex> lock(chainLock);
     const Json::Value jsonTx = transactions->get(transaction, id);
     if(!jsonTx.isObject()) {
         throw NotFoundException("Transaction " + id);
@@ -912,8 +888,6 @@ void CryptoKernel::Blockchain::emptyDB() {
 }
 
 CryptoKernel::Storage::Transaction* CryptoKernel::Blockchain::getTxHandle() {
-    //chainLock.lock();
-    //Storage::Transaction* dbTx = blockdb->begin(chainLock);
     Storage::Transaction* dbTx = blockdb->beginReadOnly();
     return dbTx;
 }

--- a/src/kernel/blockchain.h
+++ b/src/kernel/blockchain.h
@@ -389,6 +389,7 @@ private:
 	};
 
     Mempool unconfirmedTransactions;
+    std::mutex mempoolMutex;
 
     std::string dbDir;
 
@@ -401,7 +402,6 @@ private:
     bool status;
     void reverseBlock(Storage::Transaction* dbTransaction);
     bool reorgChain(Storage::Transaction* dbTransaction, const BigNum& newTipId);
-    //std::recursive_mutex chainLock;
     virtual uint64_t getBlockReward(const uint64_t height) = 0;
     virtual std::string getCoinbaseOwner(const std::string& publicKey) = 0;
     Consensus* consensus;

--- a/src/kernel/blockchain.h
+++ b/src/kernel/blockchain.h
@@ -401,7 +401,7 @@ private:
     bool status;
     void reverseBlock(Storage::Transaction* dbTransaction);
     bool reorgChain(Storage::Transaction* dbTransaction, const BigNum& newTipId);
-    std::recursive_mutex chainLock;
+    //std::recursive_mutex chainLock;
     virtual uint64_t getBlockReward(const uint64_t height) = 0;
     virtual std::string getCoinbaseOwner(const std::string& publicKey) = 0;
     Consensus* consensus;

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -242,6 +242,16 @@ void CryptoKernel::Network::peerFunc() {
             }
 
             dbTx->commit();
+
+            std::lock_guard<std::mutex> cLock(connectedStatsMutex);
+            connectedStats.clear();
+
+            for(const auto& peer : connected) {
+                peerStats stats = peer.second->peer->getPeerStats();
+                stats.version = peer.second->info["version"].asString();
+                stats.blockHeight = peer.second->info["height"].asUInt64();
+                connectedStats.insert(std::make_pair(peer.first, stats));
+            }
         }
 
         if(wait) {
@@ -563,16 +573,7 @@ uint64_t CryptoKernel::Network::getCurrentHeight() {
 
 std::map<std::string, CryptoKernel::Network::peerStats>
 CryptoKernel::Network::getPeerStats() {
-    std::lock_guard<std::recursive_mutex> lock(connectedMutex);
+    std::lock_guard<std::mutex> lock(connectedStatsMutex);
 
-    std::map<std::string, peerStats> returning;
-
-    for(const auto& peer : connected) {
-        peerStats stats = peer.second->peer->getPeerStats();
-        stats.version = peer.second->info["version"].asString();
-        stats.blockHeight = peer.second->info["height"].asUInt64();
-        returning.insert(std::make_pair(peer.first, stats));
-    }
-
-    return returning;
+    return connectedStats;
 }

--- a/src/kernel/network.h
+++ b/src/kernel/network.h
@@ -105,6 +105,9 @@ private:
     std::map<std::string, std::unique_ptr<PeerInfo>> connected;
     std::recursive_mutex connectedMutex;
 
+    std::map<std::string, peerStats> connectedStats;
+    std::mutex connectedStatsMutex;
+
     CryptoKernel::Log* log;
     CryptoKernel::Blockchain* blockchain;
 

--- a/src/kernel/storage.h
+++ b/src/kernel/storage.h
@@ -19,6 +19,7 @@
 #define STORAGE_H_INCLUDED
 
 #include <mutex>
+#include <memory>
 
 #include <json/writer.h>
 #include <json/reader.h>

--- a/src/kernel/storage.h
+++ b/src/kernel/storage.h
@@ -76,7 +76,7 @@ public:
         Storage* db;
         bool finished;
         bool readonly;
-        std::shared_ptr<const leveldb::Snapshot> snapshot;
+        const leveldb::Snapshot* snapshot;
         std::recursive_mutex* mut;
     };
 

--- a/src/kernel/storage.h
+++ b/src/kernel/storage.h
@@ -53,8 +53,8 @@ public:
 
     class Transaction {
     public:
-        Transaction(Storage* db);
-        Transaction(Storage* db, std::recursive_mutex& mut);
+        Transaction(Storage* db, const bool readonly = false);
+        Transaction(Storage* db, std::recursive_mutex& mut, const bool readonly = false);
 
         ~Transaction();
 
@@ -75,12 +75,16 @@ public:
         std::map<std::string, dbObject> dbStateCache;
         Storage* db;
         bool finished;
+        bool readonly;
+        std::shared_ptr<const leveldb::Snapshot> snapshot;
         std::recursive_mutex* mut;
     };
 
     Transaction* begin();
 
     Transaction* begin(std::recursive_mutex& mut);
+
+    Transaction* beginReadOnly();
 
     class Table {
     public:
@@ -168,7 +172,8 @@ public:
 
 private:
     leveldb::DB* db;
-    std::mutex dbMutex;
+    std::mutex readLock;
+    std::mutex writeLock;
     bool sync;
 };
 }


### PR DESCRIPTION
Previously lock contention was very high while the blockchain was syncing. This meant many RPC calls would timeout. Instead make use of leveldb snapshots and peerInfo caching internally to the blockchain and network to prevent waiting on several locks. This is at the cost of slightly stale data from RPC. 