### PR TITLE
Improve transaction commit speed by changing the publicKey index method

### DIFF
--- a/src/kernel/blockchain.cpp
+++ b/src/kernel/blockchain.cpp
@@ -562,31 +562,6 @@ void CryptoKernel::Blockchain::confirmTransaction(Storage::Transaction* dbTransa
         stxos->put(dbTransaction, outputId, utxo);
 
         if(!txoData["publicKey"].isNull()) {
-            /*Json::Value txos = stxos->get(dbTransaction,
-                                          txoData["publicKey"].asString(),
-                                          0);
-            txos.append(outputId);
-            stxos->put(dbTransaction,
-                       txoData["publicKey"].asString(),
-                       txos,
-                       0);
-
-            txos = utxos->get(dbTransaction,
-                              txoData["publicKey"].asString(),
-                              0);
-
-            Json::Value newTxos;
-            for(const auto& txo : txos) {
-                if(txo.asString() != outputId) {
-                    newTxos.append(txo);
-                }
-            }
-
-            utxos->put(dbTransaction,
-                       txoData["publicKey"].asString(),
-                       newTxos,
-                       0);*/
-
             const auto txoStr = txoData["publicKey"].asString() + outputId;
 
             stxos->put(dbTransaction, txoStr, Json::nullValue, 0);
@@ -602,15 +577,6 @@ void CryptoKernel::Blockchain::confirmTransaction(Storage::Transaction* dbTransa
     for(const output& out : tx.getOutputs()) {
         const auto txoData = out.getData();
         if(!txoData["publicKey"].isNull()) {
-            /*Json::Value txos = utxos->get(dbTransaction,
-                                          txoData["publicKey"].asString(),
-                                          0);
-            txos.append(out.getId().toString());
-            utxos->put(dbTransaction,
-                       txoData["publicKey"].asString(),
-                       txos,
-                       0);*/
-
             const auto txoStr = txoData["publicKey"].asString() + out.getId().toString();
             utxos->put(dbTransaction, txoStr, Json::nullValue, 0);
         }
@@ -780,24 +746,6 @@ void CryptoKernel::Blockchain::reverseBlock(Storage::Transaction* dbTransaction)
 
         const auto txoData = out.getData();
         if(!txoData["publicKey"].isNull()) {
-            /*const Json::Value txos = db->get(dbTransaction,
-                                          txoData["publicKey"].asString(),
-                                          0);
-
-            const auto outputId = out.getId().toString();
-
-            Json::Value newTxos;
-            for(const auto& txo : txos) {
-                if(txo.asString() != outputId) {
-                    newTxos.append(txo);
-                }
-            }
-
-            db->put(dbTransaction,
-                       txoData["publicKey"].asString(),
-                       newTxos,
-                       0);*/
-
             const auto txoStr = txoData["publicKey"].asString() + out.getId().toString();
             db->erase(dbTransaction, txoStr, 0);
         }
@@ -827,15 +775,6 @@ void CryptoKernel::Blockchain::reverseBlock(Storage::Transaction* dbTransaction)
             utxos->put(dbTransaction, oldOutputId, oldOutput.toJson());
             const auto txoData = oldOutput.getData();
             if(!txoData["publicKey"].isNull()) {
-                /*Json::Value txos = utxos->get(dbTransaction,
-                                              txoData["publicKey"].asString(),
-                                              0);
-                txos.append(oldOutputId);
-                utxos->put(dbTransaction,
-                           txoData["publicKey"].asString(),
-                           txos,
-                           0);*/
-
                 const auto txoStr = txoData["publicKey"].asString() + oldOutputId;
                 utxos->put(dbTransaction, txoStr, Json::nullValue, 0);
             }

--- a/src/kernel/consensus/regtest.cpp
+++ b/src/kernel/consensus/regtest.cpp
@@ -1,5 +1,6 @@
 #include <sstream>
 #include <math.h>
+#include <random>
 
 #include "regtest.h"
 #include "../crypto.h"
@@ -67,7 +68,15 @@ void CryptoKernel::Consensus::Regtest::mineBlock(const bool isBetter, const std:
 	Json::Value consensusData = Block.getConsensusData();
 	consensusData["isBetter"] = isBetter;
 	Block.setConsensusData(consensusData);
-	blockchain->submitBlock(Block);
+
+    std::random_device r;
+    std::default_random_engine generator(r());
+    std::uniform_int_distribution<uint64_t> distribution(0, std::numeric_limits<uint64_t>::max());
+
+	auto blockJson = Block.toJson();
+	blockJson["coinbaseTx"]["outputs"][0]["nonce"] = distribution(generator);
+		
+	blockchain->submitBlock(CryptoKernel::Blockchain::block(blockJson));
 }
 
 CryptoKernel::Consensus::Regtest::consensusData

--- a/src/kernel/storage.cpp
+++ b/src/kernel/storage.cpp
@@ -250,8 +250,9 @@ leveldb::Snapshot* snapshot, const std::string& prefix, const int index) {
     
     leveldb::ReadOptions options;
 
+    this->snapshot = snapshot;
+
     if(snapshot != nullptr) {
-        this->snapshot = snapshot;
         options.snapshot = snapshot;
     } else {
          db->writeLock.lock();

--- a/src/kernel/storage.cpp
+++ b/src/kernel/storage.cpp
@@ -260,7 +260,7 @@ leveldb::Snapshot* snapshot, const std::string& prefix, const int index) {
 
     it = db->db->NewIterator(options);
 
-    this->prefix = table->getKey("");
+    this->prefix = table->getKey("", index);
 
     if(prefix != "") {
         this->prefix += prefix;

--- a/src/kernel/storage.h
+++ b/src/kernel/storage.h
@@ -68,6 +68,8 @@ public:
 
         bool ended();
 
+        const leveldb::Snapshot* snapshot;
+
     private:
         struct dbObject {
             Json::Value data;
@@ -77,7 +79,6 @@ public:
         Storage* db;
         bool finished;
         bool readonly;
-        const leveldb::Snapshot* snapshot;
         std::recursive_mutex* mut;
     };
 
@@ -98,7 +99,8 @@ public:
 
         class Iterator {
         public:
-            Iterator(Table* table, Storage* db);
+            Iterator(Table* table, Storage* db, const leveldb::Snapshot* snapshot = nullptr,
+                     const std::string& prefix = "", const int index = -1);
 
             ~Iterator();
 
@@ -137,6 +139,7 @@ public:
             Table* table;
             Storage* db;
             std::string prefix;
+            const leveldb::Snapshot* snapshot;
         };
 
         std::string getKey(const std::string& key, const int index = -1);

--- a/tests/BlockchainTests.cpp
+++ b/tests/BlockchainTests.cpp
@@ -9,21 +9,21 @@ BlockchainTest::BlockchainTest() {
     log.reset(new CryptoKernel::Log("tests.log"));
 }
 
-BlockchainTest::~BlockchainTest() {
-    CryptoKernel::Storage::destroy("./testblockdb");
-}
+BlockchainTest::~BlockchainTest() {}
 
 void BlockchainTest::setUp() {
-    std::remove("genesistest.json");
-    CryptoKernel::Storage::destroy("./testblockdb");
-
     blockchain.reset(new testChain(log.get()));
     consensus.reset(new CryptoKernel::Consensus::Regtest(blockchain.get()));
     blockchain->loadChain(consensus.get(), "genesistest.json");
     consensus->start();
 }
 
-void BlockchainTest::tearDown() {}
+void BlockchainTest::tearDown() {
+    blockchain.reset();
+    consensus.reset();
+    std::remove("genesistest.json");
+    CryptoKernel::Storage::destroy("./testblockdb");
+}
 
 BlockchainTest::testChain::testChain(CryptoKernel::Log* GlobalLog) : CryptoKernel::Blockchain(GlobalLog, "./testblockdb") {}
 
@@ -60,4 +60,25 @@ void BlockchainTest::testVerifyMalformedSignature() {
     const auto res = blockchain->submitTransaction(tx);
 
     CPPUNIT_ASSERT(!std::get<0>(res));
+}
+
+void BlockchainTest::testListUnspentOutputsFromCoinbase() {
+    const std::string pubKey = "BL2AcSzFw2+rGgQwJ25r7v/misIvr3t4JzkH3U1CCknchfkncSneKLBo6tjnKDhDxZUSPXEKMDtTU/YsvkwxJR8=";
+
+    // Mine three blocks
+    for(int i = 0; i < 3; i++) {    
+        consensus->mineBlock(true, pubKey);
+    }
+
+    // Ensure three blocks were actually mined
+    blockchain->getBlockByHeight(3);
+
+    const auto outs = blockchain->getUnspentOutputs(pubKey);
+
+    CPPUNIT_ASSERT_EQUAL(size_t(3), outs.size());
+    
+    for(const auto& out : outs) {
+        CPPUNIT_ASSERT_EQUAL(pubKey, out.getData()["publicKey"].asString());
+        CPPUNIT_ASSERT_EQUAL(uint64_t(100000000), out.getValue());
+    }
 }

--- a/tests/BlockchainTests.cpp
+++ b/tests/BlockchainTests.cpp
@@ -71,7 +71,7 @@ void BlockchainTest::testListUnspentOutputsFromCoinbase() {
     }
 
     // Ensure three blocks were actually mined
-    blockchain->getBlockByHeight(3);
+    blockchain->getBlockByHeight(4);
 
     const auto outs = blockchain->getUnspentOutputs(pubKey);
 

--- a/tests/BlockchainTests.h
+++ b/tests/BlockchainTests.h
@@ -9,6 +9,7 @@ class BlockchainTest : public CPPUNIT_NS::TestFixture {
     CPPUNIT_TEST_SUITE(BlockchainTest);
 
     CPPUNIT_TEST(testVerifyMalformedSignature);
+    CPPUNIT_TEST(testListUnspentOutputsFromCoinbase);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -30,6 +31,7 @@ private:
 
 
     void testVerifyMalformedSignature();
+    void testListUnspentOutputsFromCoinbase();
 
     std::unique_ptr<CryptoKernel::Blockchain> blockchain;
     std::unique_ptr<CryptoKernel::Log> log;


### PR DESCRIPTION
Previously to keep track of the map of `publicKey`s to unspent and spent outputs we used a JSON array with one key per public key. If a given public key was used many times, this would lead to a very large JSON object being retrieved from and saved to the database for every output using that public key. This lead to cache misses and large wait times for database operations.

Instead, play to leveldb's strengths by using one key per output and retreiving the list of outputs for a public key using an iterator. This means the speed to update the public key/output map is now almost constant rather than linear with the number of outputs associated with a public key.

The PR also adds a unit test for basic `getUnspentOutputs` functionality.