### PR TITLE
Docker container for ckd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:18.04
+RUN apt-get update
+RUN apt-get install -y sudo wget
+RUN echo "ca_directory=/etc/ssl/certs" > /root/.wgetrc
+
+RUN adduser --disabled-password --gecos '' docker
+RUN adduser docker sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+USER docker
+RUN echo "ca_directory=/etc/ssl/certs" > /home/docker/.wgetrc
+COPY ./installdeps.sh /tmp
+WORKDIR /tmp
+RUN ./installdeps.sh
+
+RUN mkdir /tmp/src 
+COPY . /tmp/src/
+WORKDIR /tmp/src
+RUN premake5 gmake2 --include-dir=/usr/include/lua5.3
+RUN make
+
+USER root
+WORKDIR /tmp/src
+RUN mkdir -p /app/bin 
+RUN cp bin/Static/Debug/ckd /app/bin
+WORKDIR /app/bin
+
+COPY config.json /app/bin
+COPY peers.txt /app/bin 
+COPY genesisblock.json /app/bin 
+
+CMD ["/app/bin/ckd"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,12 @@ RUN mkdir /tmp/src
 COPY . /tmp/src/
 WORKDIR /tmp/src
 RUN premake5 gmake2 --include-dir=/usr/include/lua5.3
-RUN make
+RUN make config=release_static
 
 USER root
 WORKDIR /tmp/src
 RUN mkdir -p /app/bin 
-RUN cp bin/Static/Debug/ckd /app/bin
+RUN cp bin/Static/Release/ckd /app/bin
 WORKDIR /app/bin
 
 COPY config.json /app/bin


### PR DESCRIPTION
Added a dockerfile that runs the `installdeps.sh` and builds. It uses ckd as the main entrypoint.

You can use this by first running:

`docker run --name cryptokernel -ti {image tag}`

and then in another terminal you can do:

`docker exec -ti cryptokernel /app/bin/ckd getinfo`