### PR TITLE
Fix bug where lz4 couldn't be loaded with the linux static build

### DIFF
--- a/build/linux/Dockerfile
+++ b/build/linux/Dockerfile
@@ -69,11 +69,11 @@ WORKDIR ../
 
 RUN wget https://www.lua.org/ftp/lua-5.3.4.tar.gz && \
     tar xzvf lua-5.3.4.tar.gz
-WORKDIR lua-5.3.4
-RUN make generic && make local && cp -r install/lib/liblua.a /usr/local/lib/liblua5.3.a && \
-    cp -r install/include/* /usr/local/include/
+WORKDIR lua-5.3.4/src
+RUN make liblua.a SYSCFLAGS="-DLUA_USE_LINUX" && cp liblua.a /usr/local/lib/liblua5.3.a && \
+    mkdir /usr/include/lua5.3 && cp -r *.h /usr/include/lua5.3
 
-WORKDIR ../
+WORKDIR ../../
 
 RUN git clone https://github.com/metalicjames/selene.git
 RUN cp -r selene/include/* /usr/local/include
@@ -102,4 +102,4 @@ WORKDIR ../
 
 WORKDIR cryptokernel
 
-RUN premake5 gmake2 && make ckd
+RUN premake5 gmake2 --include-dir=/usr/include/lua5.3 && make ckd

--- a/premake5.lua
+++ b/premake5.lua
@@ -31,7 +31,7 @@ workspace "CryptoKernel"
     filter {"configurations:Release"}
         optimize "Full"
 
-    filter "system:windows"
+    filter "system:linux"
         linkoptions {"-rdynamic"}
 
 cklibs = {"crypto", "sfml-network", 

--- a/premake5.lua
+++ b/premake5.lua
@@ -24,13 +24,15 @@ workspace "CryptoKernel"
                  _OPTIONS["include-dir"]}
     libdirs {_OPTIONS["lib-dir"]}
     symbols "On"
-    linkoptions {"-rdynamic"}
 
     filter {"configurations:Debug"}
         optimize "Off"
 
     filter {"configurations:Release"}
         optimize "Full"
+
+    filter "system:windows"
+        linkoptions {"-rdynamic"}
 
 cklibs = {"crypto", "sfml-network", 
 "sfml-system", "leveldb", "jsoncpp", "jsonrpccpp-server", 

--- a/premake5.lua
+++ b/premake5.lua
@@ -24,6 +24,7 @@ workspace "CryptoKernel"
                  _OPTIONS["include-dir"]}
     libdirs {_OPTIONS["lib-dir"]}
     symbols "On"
+    linkoptions {"-rdynamic"}
 
     filter {"configurations:Debug"}
         optimize "Off"


### PR DESCRIPTION
This prevents the Linux static binary from syncing up as it's unable to verify Lua scripts. The solution was the build the linux target for Lua and compiling ckd with rdynamic.