### PR TITLE
Remove mutex protecting peer socket

### DIFF
--- a/src/kernel/networkpeer.h
+++ b/src/kernel/networkpeer.h
@@ -27,9 +27,15 @@ public:
 
     class NetworkError : std::exception {
     public:
-        virtual const char* what() const throw() {
-            return "Error contacting peer";
+        NetworkError(const std::string& err) {
+            msg = err;
         }
+
+        virtual const char* what() const throw() {
+            return msg.c_str();
+        }
+    private:
+        std::string msg;
     };
 
 private:


### PR DESCRIPTION
Remove mutex protecting `sf::TcpSocket` (turns out we probably don't need it and can have blocking socket calls instead of looping). This results in a decent reduction in CPU idle usage since most threads are now sleeping. Also added useful log messages to `Peer::NetworkErrors` for easier debugging. 