### PR TITLE
Make release binaries using dockerfiles

### DIFF
--- a/build/linux/Dockerfile
+++ b/build/linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:16.04
 
 RUN apt update && apt dist-upgrade -y && \
     apt install -y make git cmake wget build-essential
@@ -94,7 +94,7 @@ RUN cp lua-lz4/lz4.so cryptokernel
 
 RUN git clone https://github.com/metalicjames/cschnorr.git
 WORKDIR cschnorr
-RUN premake5 gmake2 && make cschnorr && \
+RUN premake5 gmake2 && make config=release_static cschnorr && \
     mkdir /usr/local/include/cschnorr/ && \
     cp src/*.h /usr/local/include/cschnorr/ && \
     cp bin/Static/Debug/libcschnorr.a /usr/local/lib
@@ -102,4 +102,4 @@ WORKDIR ../
 
 WORKDIR cryptokernel
 
-RUN premake5 gmake2 --include-dir=/usr/include/lua5.3 && make ckd
+RUN premake5 gmake2 --include-dir=/usr/include/lua5.3 && make config=release_static ckd

--- a/build/linux/Dockerfile
+++ b/build/linux/Dockerfile
@@ -97,7 +97,7 @@ WORKDIR cschnorr
 RUN premake5 gmake2 && make config=release_static cschnorr && \
     mkdir /usr/local/include/cschnorr/ && \
     cp src/*.h /usr/local/include/cschnorr/ && \
-    cp bin/Static/Debug/libcschnorr.a /usr/local/lib
+    cp bin/Static/Release/libcschnorr.a /usr/local/lib
 WORKDIR ../
 
 WORKDIR cryptokernel

--- a/build/macos/Dockerfile
+++ b/build/macos/Dockerfile
@@ -63,7 +63,7 @@ WORKDIR cschnorr
 RUN premake5 gmake2 --os=macosx --include-dir=/osxcross/target/macports/pkgs/opt/local/include && make config=release_static cschnorr && \
     mkdir /osxcross/target/macports/pkgs/opt/local/include/cschnorr/ && \
     cp src/*.h /osxcross/target/macports/pkgs/opt/local/include/cschnorr/ && \
-    cp bin/Static/Debug/libcschnorr.a /osxcross/target/macports/pkgs/opt/local/lib
+    cp bin/Static/Release/libcschnorr.a /osxcross/target/macports/pkgs/opt/local/lib
 WORKDIR ../
 
 WORKDIR cryptokernel

--- a/build/macos/Dockerfile
+++ b/build/macos/Dockerfile
@@ -60,7 +60,7 @@ RUN cp lua-lz4/lz4.so cryptokernel
 
 RUN git clone https://github.com/metalicjames/cschnorr.git
 WORKDIR cschnorr
-RUN premake5 gmake2 --os=macosx --include-dir=/osxcross/target/macports/pkgs/opt/local/include && make cschnorr && \
+RUN premake5 gmake2 --os=macosx --include-dir=/osxcross/target/macports/pkgs/opt/local/include && make config=release_static cschnorr && \
     mkdir /osxcross/target/macports/pkgs/opt/local/include/cschnorr/ && \
     cp src/*.h /osxcross/target/macports/pkgs/opt/local/include/cschnorr/ && \
     cp bin/Static/Debug/libcschnorr.a /osxcross/target/macports/pkgs/opt/local/lib
@@ -68,7 +68,7 @@ WORKDIR ../
 
 WORKDIR cryptokernel
 RUN premake5 gmake2 --os=macosx --include-dir=/osxcross/target/macports/pkgs/opt/local/include --lib-dir=/osxcross/target/macports/pkgs/opt/local/lib && \
-    make ckd
+    make config=release_static ckd
 
 RUN ln -s /osxcross/target/bin/x86_64-apple-darwin15-otool /osxcross/target/bin/otool && ln -s /osxcross/target/bin/x86_64-apple-darwin15-install_name_tool /osxcross/target/bin/install_name_tool && rm -r /opt && ln -s /osxcross/target/macports/pkgs/opt /opt
 

--- a/build/macos/Dockerfile
+++ b/build/macos/Dockerfile
@@ -72,4 +72,4 @@ RUN premake5 gmake2 --os=macosx --include-dir=/osxcross/target/macports/pkgs/opt
 
 RUN ln -s /osxcross/target/bin/x86_64-apple-darwin15-otool /osxcross/target/bin/otool && ln -s /osxcross/target/bin/x86_64-apple-darwin15-install_name_tool /osxcross/target/bin/install_name_tool && rm -r /opt && ln -s /osxcross/target/macports/pkgs/opt /opt
 
-RUN dylibbundler -b -x bin/Static/Debug/ckd -cd -i /usr/lib/ -p @executable_path/libs/
+RUN dylibbundler -b -x bin/Static/Release/ckd -cd -i /usr/lib/ -p @executable_path/libs/

--- a/build/win64/Dockerfile
+++ b/build/win64/Dockerfile
@@ -111,7 +111,7 @@ WORKDIR cschnorr
 RUN premake5 gmake2 --os=windows --include-dir=/usr/local/mingw/include && make config=release_static cschnorr && \
     mkdir /usr/local/mingw/include/cschnorr/ && \
     cp src/*.h /usr/local/mingw/include/cschnorr/ && \
-    cp bin/Static/Debug/cschnorr.lib /usr/local/mingw/lib
+    cp bin/Static/Release/cschnorr.lib /usr/local/mingw/lib
 WORKDIR ../
 
 WORKDIR cryptokernel

--- a/build/win64/Dockerfile
+++ b/build/win64/Dockerfile
@@ -108,7 +108,7 @@ RUN cp lua-lz4/lz4.dll cryptokernel
 
 RUN git clone https://github.com/metalicjames/cschnorr.git
 WORKDIR cschnorr
-RUN premake5 gmake2 --os=windows --include-dir=/usr/local/mingw/include && make cschnorr && \
+RUN premake5 gmake2 --os=windows --include-dir=/usr/local/mingw/include && make config=release_static cschnorr && \
     mkdir /usr/local/mingw/include/cschnorr/ && \
     cp src/*.h /usr/local/mingw/include/cschnorr/ && \
     cp bin/Static/Debug/cschnorr.lib /usr/local/mingw/lib
@@ -116,4 +116,4 @@ WORKDIR ../
 
 WORKDIR cryptokernel
 RUN premake5 gmake2 --os=windows --include-dir=/usr/local/mingw/include --lib-dir=/usr/local/mingw/lib
-RUN make ckd
+RUN make config=release_static ckd


### PR DESCRIPTION
This will strip the symbols and compile with the optimisations turned on. Also use ubuntu 16.04 as the build base for Linux to cater for older libc versions.