### PR TITLE
Signature aggregation in transactions

### DIFF
--- a/src/kernel/blockchain.cpp
+++ b/src/kernel/blockchain.cpp
@@ -376,11 +376,15 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::verifyTransaction(Storage::Tran
                 return std::make_tuple(false, true);
             }
 
+            std::set<dbOutput> removals;
             for(const auto out : signs) {
                 auto it = maybeAggregated.begin();
                 std::advance(it, out);
+                removals.emplace(*it);
+            }
 
-                maybeAggregated.erase(it);
+            for(const auto& out : removals) {
+                maybeAggregated.erase(out);
             }
         }
     }

--- a/src/kernel/blockchain.cpp
+++ b/src/kernel/blockchain.cpp
@@ -344,13 +344,13 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::verifyTransaction(Storage::Tran
             }
 
             std::set<std::string> pubkeys;
-            std::set<std::string> outputIds;
+            std::set<BigNum> outputIds;
             for(const auto out : signs) {
                 auto it = maybeAggregated.begin();
                 std::advance(it, out);
 
                 pubkeys.emplace(it->getData()["schnorrKey"].asString());
-                outputIds.emplace(it->getId().toString());
+                outputIds.emplace(it->getId());
             }
 
             CryptoKernel::Schnorr schnorr;
@@ -363,7 +363,7 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::verifyTransaction(Storage::Tran
 
             std::string signaturePayload;
             for(const auto& id : outputIds) {
-                signaturePayload += id;
+                signaturePayload += id.toString();
             }
             signaturePayload += outputHash.toString();
 

--- a/src/kernel/blockchain.cpp
+++ b/src/kernel/blockchain.cpp
@@ -355,7 +355,6 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::verifyTransaction(Storage::Tran
 
             CryptoKernel::Schnorr schnorr;
             const std::string aggregatedPubkey = schnorr.pubkeyAggregate(pubkeys);
-            log->printf(LOG_LEVEL_INFO, aggregatedPubkey);
             if(!schnorr.setPublicKey(aggregatedPubkey)) {
                 log->printf(LOG_LEVEL_INFO,
                             "blockchain::verifyTransaction(): Aggregate signature malformed. Aggregated pubkey is invalid");
@@ -367,8 +366,6 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::verifyTransaction(Storage::Tran
                 signaturePayload += id.toString();
             }
             signaturePayload += outputHash.toString();
-
-            log->printf(LOG_LEVEL_INFO, signaturePayload);
 
             if(!schnorr.verify(signaturePayload, spendData["aggregateSignature"]["signature"].asString())) {
                 log->printf(LOG_LEVEL_INFO,

--- a/src/kernel/blockchain.cpp
+++ b/src/kernel/blockchain.cpp
@@ -348,6 +348,13 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::verifyTransaction(Storage::Tran
                                 "blockchain::verifyTransaction(): Could not verify input signature");
                     return std::make_tuple(false, true);
                 }
+
+                for(const auto out : signs) {
+                    auto it = maybeAggregated.begin();
+                    std::advance(it, out);
+
+                    maybeAggregated.erase(it);
+                }
             }
         }
 

--- a/src/kernel/blockchain.cpp
+++ b/src/kernel/blockchain.cpp
@@ -257,6 +257,8 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::verifyTransaction(Storage::Tran
 
     const CryptoKernel::BigNum outputHash = tx.getOutputSetId();
 
+    std::set<dbOutput> maybeAggregated;
+
     for(const input& inp : tx.getInputs()) {
         const Json::Value outJson = utxos->get(dbTransaction, inp.getOutputId().toString());
         if(!outJson.isObject()) {
@@ -273,18 +275,75 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::verifyTransaction(Storage::Tran
         if(!outData["schnorrKey"].empty() && outData["contract"].empty()) {
             const Json::Value spendData = inp.getData();
             if(spendData["signature"].empty() || !spendData["signature"].isString()) {
-                log->printf(LOG_LEVEL_INFO,
-                            "blockchain::verifyTransaction(): Could not verify input signature");
-                return std::make_tuple(false, true);
+                maybeAggregated.emplace(out);
             }
 
             if(!outData["schnorrKey"].isString()) {
                 log->printf(LOG_LEVEL_WARN, "blockchain::verifyTransaction(): Output has a malformed schnorr key, not checking its signature");
-            } else {
+                maybeAggregated.erase(out);
+            } else if(spendData["signature"].isString()) {
                 CryptoKernel::Schnorr schnorr;
-                schnorr.setPublicKey(outData["schnorrKey"].asString());
+                if(!schnorr.setPublicKey(outData["schnorrKey"].asString())) {
+                    log->printf(LOG_LEVEL_INFO,
+                                "blockchain::verifyTransaction(): Schnorr key is malformed");
+                    return std::make_tuple(false, true);
+                }
+
                 if(!schnorr.verify(out.getId().toString() + outputHash.toString(),
                                 spendData["signature"].asString())) {
+                    log->printf(LOG_LEVEL_INFO,
+                                "blockchain::verifyTransaction(): Could not verify input signature");
+                    return std::make_tuple(false, true);
+                }
+            } else if(spendData["aggregateSignature"].isObject()) {
+                if(!spendData["aggregateSignature"]["signs"].isArray() || !spendData["aggregateSignature"]["signature"].isString()) {
+                    log->printf(LOG_LEVEL_INFO,
+                                "blockchain::verifyTransaction(): Aggregate signature malformed");
+                    return std::make_tuple(false, true);
+                }
+                
+                std::set<uint64_t> signs;
+                for(const auto& v : spendData["aggregateSignature"]["signs"]) {
+                    if(!v.isUInt64()) {
+                        log->printf(LOG_LEVEL_INFO,
+                                "blockchain::verifyTransaction(): Aggregate signature malformed");
+                        return std::make_tuple(false, true);
+                    }
+
+                    if(v.asUInt64() >= maybeAggregated.size()) {
+                        log->printf(LOG_LEVEL_INFO,
+                                "blockchain::verifyTransaction(): Aggregate signature malformed");
+                        return std::make_tuple(false, true);
+                    }
+
+                    signs.emplace(v.asUInt64());
+                }
+
+                std::set<std::string> pubkeys;
+                std::set<std::string> outputIds;
+                for(const auto out : signs) {
+                    auto it = maybeAggregated.begin();
+                    std::advance(it, out);
+
+                    pubkeys.emplace(it->getData()["schnorrKey"].asString());
+                    outputIds.emplace(it->getId().toString());
+                }
+
+                CryptoKernel::Schnorr schnorr;
+                const std::string aggregatedPubkey = schnorr.pubkeyAggregate(pubkeys);
+                if(!schnorr.setPublicKey(aggregatedPubkey)) {
+                    log->printf(LOG_LEVEL_INFO,
+                                "blockchain::verifyTransaction(): Aggregate signature malformed");
+                    return std::make_tuple(false, true);
+                }
+
+                std::string signaturePayload;
+                for(const auto& id : outputIds) {
+                    signaturePayload += id;
+                }
+                signaturePayload += outputHash.toString();
+
+                if(!schnorr.verify(signaturePayload, spendData["aggregateSignature"]["signature"].asString())) {
                     log->printf(LOG_LEVEL_INFO,
                                 "blockchain::verifyTransaction(): Could not verify input signature");
                     return std::make_tuple(false, true);
@@ -309,6 +368,13 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::verifyTransaction(Storage::Tran
                 return std::make_tuple(false, true);
             }
         }
+    }
+
+    // There are leftover inputs that weren't covered by an aggregate signature
+    if(!maybeAggregated.empty()) {
+        log->printf(LOG_LEVEL_INFO,
+                            "blockchain::verifyTransaction(): Could not verify input signature. Schnorr output not signed or covered by aggregate signature");
+        return std::make_tuple(false, true);
     }
 
     if(!coinbaseTx) {

--- a/src/kernel/schnorr.h
+++ b/src/kernel/schnorr.h
@@ -17,6 +17,7 @@ Copyright (C) 2016  James Lovejoy
 
 #include <string>
 #include <memory>
+#include <set>
 
 #include <cschnorr/multisig.h>
 #include <json/value.h>
@@ -63,6 +64,14 @@ public:
     * @return true if the signature is correctly verified against the message and public key, false otherwise
     */
     bool verify(const std::string& message, const std::string& signature);
+
+    /**
+     * Aggregates a set of public keys in to an aggregate public key.
+     * 
+     * @param pubkeys a set of pubkeys to be aggregated
+     * @return the aggregated pubkey if successful, empty string otherwise
+     */
+    std::string pubkeyAggregate(const std::set<std::string>& pubkeys);
 
     /**
     * Returns the public key of the instance

--- a/src/kernel/schnorr.h
+++ b/src/kernel/schnorr.h
@@ -67,7 +67,7 @@ public:
 
     /**
      * Aggregates a set of public keys in to an aggregate public key.
-     * 
+     *
      * @param pubkeys a set of pubkeys to be aggregated
      * @return the aggregated pubkey if successful, empty string otherwise
      */
@@ -104,8 +104,9 @@ public:
     bool setPrivateKey(const std::string& privateKey);
 
 private:
-    musig_key *key;
-    schnorr_context *ctx;
+    musig_key* key;
+    musig_pubkey* pkey;
+    schnorr_context* ctx;
 };
 
 }

--- a/src/kernel/schnorr.h
+++ b/src/kernel/schnorr.h
@@ -52,9 +52,9 @@ public:
     * Generates an Schnorr signature from the given message.
     *
     * @param message the message to sign, must be non-empty
-    * @return the Schnorr signature of the message and public key as base64_encode(s + R + A)
+    * @return the Schnorr signature of the message and public key as base64_encode(s + R)
     */
-    std::string sign(const std::string& message);
+    std::string signSingle(const std::string& message);
 
     /**
     * Verifies a that a given signature verifies the given message with the public key of this class

--- a/tests/BlockchainTests.cpp
+++ b/tests/BlockchainTests.cpp
@@ -264,4 +264,12 @@ void BlockchainTest::testAggregateSchnorrSignature() {
 
     const auto outs2 = blockchain->getUnspentOutputs(outData3["publicKey"].asString());
     CPPUNIT_ASSERT_EQUAL(size_t(1), outs2.size());
+
+    musig_sig_free(sigAgg);
+    musig_sig_free(sig1);
+    musig_sig_free(sig2);
+    musig_pubkey_free(pub);
+    musig_key_free(key);
+    musig_key_free(key2);
+    schnorr_context_free(ctx);
 }

--- a/tests/BlockchainTests.cpp
+++ b/tests/BlockchainTests.cpp
@@ -1,6 +1,7 @@
 #include "BlockchainTests.h"
 
 #include "blockchain.h"
+#include "base64.h"
 #include "crypto.h"
 #include "schnorr.h"
 #include "consensus/regtest.h"
@@ -133,4 +134,115 @@ void BlockchainTest::testSingleSchnorrSignature() {
 
     const auto outs2 = blockchain->getUnspentOutputs(outData2["publicKey"].asString());
     CPPUNIT_ASSERT_EQUAL(size_t(1), outs2.size());
+}
+
+void BlockchainTest::testAggregateSchnorrSignature() {
+    CryptoKernel::Crypto crypto(true);
+
+    const auto ECDSAPubKey = crypto.getPublicKey();
+
+    consensus->mineBlock(true, ECDSAPubKey);
+
+    const auto outs = blockchain->getUnspentOutputs(ECDSAPubKey);
+    const auto& out = *outs.begin();
+
+    CryptoKernel::Schnorr schnorr;
+    CryptoKernel::Schnorr schnorr2;
+
+    Json::Value outData;
+    outData["schnorrKey"] = schnorr.getPublicKey();
+
+    Json::Value outData2;
+    outData2["schnorrKey"] = schnorr2.getPublicKey();
+
+    CryptoKernel::Blockchain::output out2((out.getValue() / 2) - 20000, 0, outData);
+    CryptoKernel::Blockchain::output out3((out.getValue() / 2) - 20000, 0, outData2);
+
+    const std::string outputSetId = CryptoKernel::Blockchain::transaction::getOutputSetId({out2, out3}).toString();
+
+    Json::Value spendData;
+    spendData["signature"] = crypto.sign(out.getId().toString() + outputSetId);
+
+    CryptoKernel::Blockchain::input inp(out.getId(), spendData);
+    CryptoKernel::Blockchain::transaction tx({inp}, {out2, out3}, 1530888581);
+
+    const auto res = blockchain->submitTransaction(tx);
+    CPPUNIT_ASSERT(std::get<0>(res));
+
+    consensus->mineBlock(true, ECDSAPubKey);
+
+    Json::Value outData3;
+    outData3["publicKey"] = "BL2AcSzFw2+rGgQwJ25r7v/misIvr3t4JzkH3U1CCknchfkncSneKLBo6tjnKDhDxZUSPXEKMDtTU/YsvkwxJR8=";
+    CryptoKernel::Blockchain::output out4(out2.getValue() - 60000, 0, outData3);
+
+    const auto outputSetId2 = CryptoKernel::Blockchain::transaction::getOutputSetId({out4}).toString();
+
+    std::set<CryptoKernel::Blockchain::output> outputSet({out2, out3});
+
+    std::string msgPayload;
+    for(const auto& o : outputSet) {
+        msgPayload += o.getId().toString();
+    }
+    msgPayload += outputSetId2;
+
+    schnorr_context* ctx = schnorr_context_new();
+
+    musig_key* key = musig_key_new(ctx);
+    musig_key* key2 = musig_key_new(ctx);
+
+    const std::string decodedKey = base64_decode(schnorr.getPrivateKey());
+
+    CPPUNIT_ASSERT(BN_bin2bn(
+            (unsigned char*)decodedKey.c_str(),
+            (unsigned int)decodedKey.size(),
+            key->a));
+
+    const std::string decodedKey2 = base64_decode(schnorr2.getPrivateKey());
+
+    CPPUNIT_ASSERT(BN_bin2bn(
+            (unsigned char*)decodedKey2.c_str(),
+            (unsigned int)decodedKey2.size(),
+            key2->a));
+
+    CPPUNIT_ASSERT(EC_POINT_mul(ctx->group, key->pub->A, NULL, ctx->G, key->a, ctx->bn_ctx));
+    CPPUNIT_ASSERT(EC_POINT_mul(ctx->group, key2->pub->A, NULL, ctx->G, key2->a, ctx->bn_ctx));
+
+    musig_pubkey* pubkeys[2];
+
+    std::set<std::string> pubkeySet({schnorr.getPublicKey(), schnorr2.getPublicKey()});
+    if(*pubkeySet.begin() == schnorr.getPublicKey()) {
+        pubkeys[0] = key->pub;
+        pubkeys[1] = key2->pub;
+    } else {
+        pubkeys[1] = key->pub;
+        pubkeys[0] = key2->pub;
+    }
+
+    musig_sig* sig1;
+    musig_sig* sig2;
+    musig_pubkey* pub;
+    CPPUNIT_ASSERT(musig_sign(ctx, &sig1, &pub, key, pubkeys, 2, (unsigned char*)msgPayload.c_str(), msgPayload.size()));
+    CPPUNIT_ASSERT(musig_sign(ctx, &sig2, &pub, key2, pubkeys, 2, (unsigned char*)msgPayload.c_str(), msgPayload.size()));
+
+    musig_sig* sigs[2];
+    sigs[0] = sig1;
+    sigs[1] = sig2;
+
+    musig_sig* sigAgg;
+    CPPUNIT_ASSERT(musig_aggregate(ctx, &sigAgg, sigs, 2));
+
+
+
+    /*Json::Value spendData2;
+    spendData2["signature"] = schnorr.sign(out2.getId().toString() + outputSetId2);
+    CryptoKernel::Blockchain::input inp2(out2.getId(), spendData2);
+    CryptoKernel::Blockchain::transaction tx2({inp2}, {out3}, 1530888581);
+
+    const auto res2 = blockchain->submitTransaction(tx2);
+    CPPUNIT_ASSERT(std::get<0>(res2));
+
+    consensus->mineBlock(true, ECDSAPubKey);
+
+    const auto outs2 = blockchain->getUnspentOutputs(outData2["publicKey"].asString());
+    CPPUNIT_ASSERT_EQUAL(size_t(1), outs2.size());*/
 }

--- a/tests/BlockchainTests.cpp
+++ b/tests/BlockchainTests.cpp
@@ -9,7 +9,7 @@
 CPPUNIT_TEST_SUITE_REGISTRATION(BlockchainTest);
 
 BlockchainTest::BlockchainTest() {
-    log.reset(new CryptoKernel::Log("tests.log", true));
+    log.reset(new CryptoKernel::Log("tests.log"));
 }
 
 BlockchainTest::~BlockchainTest() {}
@@ -123,7 +123,7 @@ void BlockchainTest::testSingleSchnorrSignature() {
     const auto outputSetId2 = CryptoKernel::Blockchain::transaction::getOutputSetId({out3}).toString();
 
     Json::Value spendData2;
-    spendData2["signature"] = schnorr.sign(out2.getId().toString() + outputSetId2);
+    spendData2["signature"] = schnorr.signSingle(out2.getId().toString() + outputSetId2);
     CryptoKernel::Blockchain::input inp2(out2.getId(), spendData2);
     CryptoKernel::Blockchain::transaction tx2({inp2}, {out3}, 1530888581);
 
@@ -184,8 +184,6 @@ void BlockchainTest::testAggregateSchnorrSignature() {
         msgPayload += o.getId().toString();
     }
     msgPayload += outputSetId2;
-
-    std::cout << msgPayload;
 
     schnorr_context* ctx = schnorr_context_new();
 

--- a/tests/BlockchainTests.h
+++ b/tests/BlockchainTests.h
@@ -12,6 +12,7 @@ class BlockchainTest : public CPPUNIT_NS::TestFixture {
     CPPUNIT_TEST(testListUnspentOutputsFromCoinbase);
     CPPUNIT_TEST(testSingleSchnorrSignature);
     CPPUNIT_TEST(testAggregateSchnorrSignature);
+    CPPUNIT_TEST(testAggregateSignatureWithUnsignedFail);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -36,6 +37,7 @@ private:
     void testListUnspentOutputsFromCoinbase();
     void testSingleSchnorrSignature();
     void testAggregateSchnorrSignature();
+    void testAggregateSignatureWithUnsignedFail();
 
     std::unique_ptr<CryptoKernel::Blockchain> blockchain;
     std::unique_ptr<CryptoKernel::Log> log;

--- a/tests/BlockchainTests.h
+++ b/tests/BlockchainTests.h
@@ -11,6 +11,7 @@ class BlockchainTest : public CPPUNIT_NS::TestFixture {
     CPPUNIT_TEST(testVerifyMalformedSignature);
     CPPUNIT_TEST(testListUnspentOutputsFromCoinbase);
     CPPUNIT_TEST(testSingleSchnorrSignature);
+    CPPUNIT_TEST(testAggregateSchnorrSignature);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -34,6 +35,7 @@ private:
     void testVerifyMalformedSignature();
     void testListUnspentOutputsFromCoinbase();
     void testSingleSchnorrSignature();
+    void testAggregateSchnorrSignature();
 
     std::unique_ptr<CryptoKernel::Blockchain> blockchain;
     std::unique_ptr<CryptoKernel::Log> log;

--- a/tests/BlockchainTests.h
+++ b/tests/BlockchainTests.h
@@ -14,6 +14,7 @@ class BlockchainTest : public CPPUNIT_NS::TestFixture {
     CPPUNIT_TEST(testAggregateSchnorrSignature);
     CPPUNIT_TEST(testAggregateSignatureWithUnsignedFail);
     CPPUNIT_TEST(testAggregateMixSignature);
+    CPPUNIT_TEST(testSchnorrMultiSignature);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -40,6 +41,7 @@ private:
     void testAggregateSchnorrSignature();
     void testAggregateSignatureWithUnsignedFail();
     void testAggregateMixSignature();
+    void testSchnorrMultiSignature();
 
     std::unique_ptr<CryptoKernel::Blockchain> blockchain;
     std::unique_ptr<CryptoKernel::Log> log;

--- a/tests/BlockchainTests.h
+++ b/tests/BlockchainTests.h
@@ -13,6 +13,7 @@ class BlockchainTest : public CPPUNIT_NS::TestFixture {
     CPPUNIT_TEST(testSingleSchnorrSignature);
     CPPUNIT_TEST(testAggregateSchnorrSignature);
     CPPUNIT_TEST(testAggregateSignatureWithUnsignedFail);
+    CPPUNIT_TEST(testAggregateMixSignature);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -38,6 +39,7 @@ private:
     void testSingleSchnorrSignature();
     void testAggregateSchnorrSignature();
     void testAggregateSignatureWithUnsignedFail();
+    void testAggregateMixSignature();
 
     std::unique_ptr<CryptoKernel::Blockchain> blockchain;
     std::unique_ptr<CryptoKernel::Log> log;

--- a/tests/BlockchainTests.h
+++ b/tests/BlockchainTests.h
@@ -10,6 +10,7 @@ class BlockchainTest : public CPPUNIT_NS::TestFixture {
 
     CPPUNIT_TEST(testVerifyMalformedSignature);
     CPPUNIT_TEST(testListUnspentOutputsFromCoinbase);
+    CPPUNIT_TEST(testSingleSchnorrSignature);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -32,6 +33,7 @@ private:
 
     void testVerifyMalformedSignature();
     void testListUnspentOutputsFromCoinbase();
+    void testSingleSchnorrSignature();
 
     std::unique_ptr<CryptoKernel::Blockchain> blockchain;
     std::unique_ptr<CryptoKernel::Log> log;

--- a/tests/SchnorrTests.cpp
+++ b/tests/SchnorrTests.cpp
@@ -41,7 +41,7 @@ void SchnorrTest::testSignVerify() {
     const std::string privateKey = schnorr->getPrivateKey();
     const std::string publicKey = schnorr->getPublicKey();
 
-    const std::string signature = schnorr->sign(plainText);
+    const std::string signature = schnorr->signSingle(plainText);
 
     CPPUNIT_ASSERT(signature.size() > 0);
     CPPUNIT_ASSERT(schnorr->verify(plainText, signature));
@@ -53,7 +53,7 @@ void SchnorrTest::testSignVerify() {
 void SchnorrTest::testPassingKeys() {
     CryptoKernel::Schnorr *tempSchnorr = new CryptoKernel::Schnorr();
 
-    const std::string signature = tempSchnorr->sign(plainText);
+    const std::string signature = tempSchnorr->signSingle(plainText);
     CPPUNIT_ASSERT(signature.size() > 0);
 
     CPPUNIT_ASSERT(schnorr->setPublicKey(tempSchnorr->getPublicKey()));
@@ -68,7 +68,7 @@ void SchnorrTest::testPassingKeys() {
 void SchnorrTest::testPermutedSigFail() {
     CryptoKernel::Schnorr *tempSchnorr = new CryptoKernel::Schnorr();
 
-    std::string signature = tempSchnorr->sign(plainText);
+    std::string signature = tempSchnorr->signSingle(plainText);
     CPPUNIT_ASSERT(signature.size() > 0);
     const std::string pubKey = tempSchnorr->getPublicKey();
 
@@ -90,7 +90,7 @@ void SchnorrTest::testPermutedSigFail() {
 void SchnorrTest::testSamePubkeyAfterSign() {
     const std::string publicKey = schnorr->getPublicKey();
 
-    schnorr->sign(plainText);
+    schnorr->signSingle(plainText);
 
     CPPUNIT_ASSERT_EQUAL(publicKey, schnorr->getPublicKey());
 }

--- a/tests/SchnorrTests.cpp
+++ b/tests/SchnorrTests.cpp
@@ -87,3 +87,10 @@ void SchnorrTest::testPermutedSigFail() {
     delete tempSchnorr;
 }
 
+void SchnorrTest::testSamePubkeyAfterSign() {
+    const std::string publicKey = schnorr->getPublicKey();
+
+    schnorr->sign(plainText);
+
+    CPPUNIT_ASSERT_EQUAL(publicKey, schnorr->getPublicKey());
+}

--- a/tests/SchnorrTests.h
+++ b/tests/SchnorrTests.h
@@ -13,6 +13,7 @@ class SchnorrTest : public CPPUNIT_NS::TestFixture {
     CPPUNIT_TEST(testSignVerify);
     CPPUNIT_TEST(testPassingKeys);
     CPPUNIT_TEST(testPermutedSigFail);
+    CPPUNIT_TEST(testSamePubkeyAfterSign);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -28,6 +29,7 @@ private:
     void testSignVerify();
     void testPassingKeys();
     void testPermutedSigFail();
+    void testSamePubkeyAfterSign();
     CryptoKernel::Schnorr *schnorr;
     const std::string plainText = "This is a test.";
 


### PR DESCRIPTION
This PR implements MuSig schnorr signature aggregation for transactions. This allows for multiple schnorr inputs to be signed with a single signature. To sign a group of schnorr outputs with an aggregate signature, leave the data field of each schnorr input to be signed without a `signature` field except for one input where you instead include an `aggregateSignature`. 

The `aggregateSignature` takes the following form:
```
"aggregateSignature": {
    "signs": [0, 3, 5],
    "signature": <base64 encoded sig>
}
```
The `signs` field enumerates the outputs that this aggregate signature covers. They are indexed by ordering all the output IDs spent in the transaction from smallest to largest. Each schnorr output may be covered by at most one aggregate signature. 

The signed message payload is the ordered output IDs concatenated together with the output set merkle root. 