### PR TITLE
Added the ability to create and verify merkle proofs

### DIFF
--- a/src/kernel/merkletree.cpp
+++ b/src/kernel/merkletree.cpp
@@ -1,5 +1,4 @@
 #include <queue>
-#include <iostream>
 #include "merkletree.h"
 #include "crypto.h"
 
@@ -69,7 +68,7 @@ std::shared_ptr<CryptoKernel::MerkleNode> CryptoKernel::MerkleNode::getRightNode
     return rightNode;
 }
 
-CryptoKernel::MerkleNode* CryptoKernel::MerkleNode::getAncestor() {
+CryptoKernel::MerkleNode* CryptoKernel::MerkleNode::getAncestor() const {
     return ancestor;
 }
 
@@ -130,22 +129,22 @@ std::shared_ptr<CryptoKernel::MerkleNode> CryptoKernel::MerkleNode::makeMerkleTr
     return nodes[0];
 }
 
-CryptoKernel::MerkleNode* CryptoKernel::MerkleNode::findDescendant(BigNum needle) {
+const CryptoKernel::MerkleNode* CryptoKernel::MerkleNode::findDescendant(const BigNum& needle) const{
     if(leftVal == needle || rightVal == needle) {
         return this;
     }
     else if(leaf) { 
         return nullptr; 
     } else {
-        CryptoKernel::MerkleNode* find;
-        find = leftNode->findDescendant(needle);
-        if(find == nullptr) find = rightNode->findDescendant(needle);
-        return find;
+        const CryptoKernel::MerkleNode* findLeft = leftNode->findDescendant(needle);
+        if(findLeft != nullptr) return findLeft;
+        const CryptoKernel::MerkleNode* findRight = rightNode->findDescendant(needle);
+        return findRight;
     }
 }
 
 std::shared_ptr<CryptoKernel::MerkleProof> CryptoKernel::MerkleNode::makeProof(BigNum proof) {
-    CryptoKernel::MerkleNode* proofNode = findDescendant(proof);
+    const CryptoKernel::MerkleNode* proofNode = findDescendant(proof);
     if(proofNode == nullptr) {
         throw CryptoKernel::Blockchain::NotFoundException("Tree node " + proof.toString());
     }
@@ -200,7 +199,7 @@ std::shared_ptr<CryptoKernel::MerkleNode> CryptoKernel::MerkleNode::makeMerkleTr
     return result;
 }
 
-Json::Value CryptoKernel::MerkleProof::toJson() {
+Json::Value CryptoKernel::MerkleProof::toJson() const {
     Json::Value result;
 
     result["position"] = positionInTotalSet;
@@ -215,7 +214,7 @@ CryptoKernel::MerkleProof::MerkleProof() {
     leaves = {};
 } 
 
-CryptoKernel::MerkleProof::MerkleProof(Json::Value& jsonProof) {
+CryptoKernel::MerkleProof::MerkleProof(const Json::Value& jsonProof) {
     if(jsonProof["position"].isNull()){
         throw CryptoKernel::Blockchain::InvalidElementException("Merkle proof JSON is malformed: Mandatory element 'position' is not found");
     }

--- a/src/kernel/merkletree.h
+++ b/src/kernel/merkletree.h
@@ -4,11 +4,26 @@
 #include <set>
 #include <memory>
 
+#include <json/writer.h>
+#include <json/reader.h>
+
 #include "ckmath.h"
+#include "blockchain.h"
 
 namespace CryptoKernel {
+    class MerkleProof {
+        public:
+            MerkleProof();
+            MerkleProof(Json::Value& json);
+            int positionInTotalSet;
+            std::vector<BigNum> leaves;
+            Json::Value toJson();
+    };
+
     class MerkleNode {
         public:
+            MerkleNode();
+            
             MerkleNode(const std::shared_ptr<MerkleNode> left, 
                        const std::shared_ptr<MerkleNode> right);
             
@@ -19,25 +34,39 @@ namespace CryptoKernel {
             MerkleNode(const BigNum& left);
             
             static std::shared_ptr<MerkleNode> makeMerkleTree(const std::set<BigNum>& leaves);
-        
+            static std::shared_ptr<CryptoKernel::MerkleNode> makeMerkleTreeFromProof(std::shared_ptr<CryptoKernel::MerkleProof> proof);
+            std::shared_ptr<CryptoKernel::MerkleProof> makeProof(BigNum proofValue);
             BigNum getMerkleRoot() const;
             
             BigNum getLeftVal() const;
             BigNum getRightVal() const;
-            
+            std::shared_ptr<MerkleNode>  getLeftNode();
+            std::shared_ptr<MerkleNode>  getRightNode();
+            MerkleNode* getAncestor();
+
         private:
-            bool leaf;
+            MerkleNode* ancestor;
             
             std::shared_ptr<MerkleNode> leftNode;
             std::shared_ptr<MerkleNode> rightNode;
-            
+
             BigNum leftVal;
             BigNum rightVal;
-            
-            BigNum root;
-            
+                        
+            CryptoKernel::MerkleNode* findDescendant(BigNum needle);
             static BigNum calcRoot(const std::string& left, const std::string& right);
+
+        protected:
+            bool leaf;
+            BigNum root;
     };
+
+    class MerkleRootNode : public MerkleNode {
+        public:
+            MerkleRootNode(const BigNum& merkleRoot);
+    };
+
+    
 }
 
 #endif // MERKLETREE_N_H_INCLUDED

--- a/src/kernel/merkletree.h
+++ b/src/kernel/merkletree.h
@@ -14,10 +14,10 @@ namespace CryptoKernel {
     class MerkleProof {
         public:
             MerkleProof();
-            MerkleProof(Json::Value& json);
+            MerkleProof(const Json::Value& json);
             int positionInTotalSet;
             std::vector<BigNum> leaves;
-            Json::Value toJson();
+            Json::Value toJson() const;
     };
 
     class MerkleNode {
@@ -42,7 +42,7 @@ namespace CryptoKernel {
             BigNum getRightVal() const;
             std::shared_ptr<MerkleNode>  getLeftNode();
             std::shared_ptr<MerkleNode>  getRightNode();
-            MerkleNode* getAncestor();
+            MerkleNode* getAncestor() const;
 
         private:
             MerkleNode* ancestor;
@@ -53,7 +53,7 @@ namespace CryptoKernel {
             BigNum leftVal;
             BigNum rightVal;
                         
-            CryptoKernel::MerkleNode* findDescendant(BigNum needle);
+            const CryptoKernel::MerkleNode* findDescendant(const BigNum& needle) const;
             static BigNum calcRoot(const std::string& left, const std::string& right);
 
         protected:

--- a/tests/MerkletreeTests.cpp
+++ b/tests/MerkletreeTests.cpp
@@ -1,4 +1,5 @@
 #include "MerkletreeTests.h"
+#include <iostream>
 
 CPPUNIT_TEST_SUITE_REGISTRATION(MerkletreeTest);
 
@@ -111,4 +112,111 @@ void MerkletreeTest::testMakeTreeFromLeaves() {
     const std::string expectedRight = "f2be8819c7e4bc3b4e2611c09d26ec93f5094e3cb36930a232654008a0ecaa50";
 
     CPPUNIT_ASSERT_EQUAL(expectedRight, actualRight);
+}
+
+
+
+void MerkletreeTest::testMakeProof() {
+    const std::string garbage = "33761f1b9133fe8a02b4bfffe94db76efbcfaf8cb1198fe9a41ef4cdfe23cc194ead2f273acada6eb89f851d65191b0a2e6b0a14cb65933ba28ddea67cac5630e60f9039e8fa0180ed9bac97bfc31da5395962ae5312082e9aebf337d12f60c574ff0623b2b6b51b0e75041c6b81fd7651d932ddda1580a98b4e2774b600a40640477f16ca5877c95dda30015c671484d8469ab8306297b5919d915793f83946c1b933b131f4a650f2e42e1c8879d85d48f8b1e8a802ba7d3a49b3e46b14c6690254ca2f495e1c7f6291c9d6c451015b7d1f6b6fc8d5b4fd46d61f2975d154fc51edbd552243a6c14171404131d6261fde5121bb817b36345cd3b1b66d296a577d3623e29bfa0f1e5e2ce42b7a82fb79952c3b190bd67f4404828c14fa5d41d4f1313a8428ed551bee1d9feea01483d0d3c19cfdb7d8652bb6745df459bf06097cf46f3899394bd8cac4002767e216a8c831a28aac3946958c24c2d28e12ed2add7337f8becd60aa3148d16f5c3134af777c441320842c01b313814a80f0b7b8dc57c06c89a3ea5554e070591a8339db913a6175425f2bafb48d91a490de40c681132bf2123bbf53421d346264e7059c4d4bf4c6d91460bd50b22838bd1a408177b2ab9255d222d97730dd995d1e2f7cda505b3c58e58fbc629203ca4142632295838fdb2f47f7c099f5d8e414e0d0ca4ef791be651c175ecc3a88b68850e3b62b4bfffe94db76efbcfc175ecc3a88b68850e3b62b3b62b4bfffe94d";
+
+    for(int j = 1; j < 200; j+=5) {
+        std::set<CryptoKernel::BigNum> nums = {};
+        for(int i = 0; i < j; i++) {
+            nums.insert(CryptoKernel::BigNum(garbage.substr(i,24)));
+        }
+    
+        CryptoKernel::MerkleNode node = CryptoKernel::MerkleNode::makeMerkleTree(nums);
+        
+
+        for(int i = 0; i < j; i++) {
+            CryptoKernel::BigNum val = CryptoKernel::BigNum(garbage.substr(i,24));
+            
+            int position = std::distance(nums.begin(), nums.find(val));
+            std::shared_ptr<CryptoKernel::MerkleProof> proof = node.makeProof(val);
+            CPPUNIT_ASSERT_EQUAL(position, proof->positionInTotalSet);
+        }
+    }
+}
+
+void MerkletreeTest::testVerifyProof() {
+    const std::string garbage = "33761f1b9133fe8a02b4bfffe94db76efbcfaf8cb1198fe9a41ef4cdfe23cc194ead2f273acada6eb89f851d65191b0a2e6b0a14cb65933ba28ddea67cac5630e60f9039e8fa0180ed9bac97bfc31da5395962ae5312082e9aebf337d12f60c574ff0623b2b6b51b0e75041c6b81fd7651d932ddda1580a98b4e2774b600a40640477f16ca5877c95dda30015c671484d8469ab8306297b5919d915793f83946c1b933b131f4a650f2e42e1c8879d85d48f8b1e8a802ba7d3a49b3e46b14c6690254ca2f495e1c7f6291c9d6c451015b7d1f6b6fc8d5b4fd46d61f2975d154fc51edbd552243a6c14171404131d6261fde5121bb817b36345cd3b1b66d296a577d3623e29bfa0f1e5e2ce42b7a82fb79952c3b190bd67f4404828c14fa5d41d4f1313a8428ed551bee1d9feea01483d0d3c19cfdb7d8652bb6745df459bf06097cf46f3899394bd8cac4002767e216a8c831a28aac3946958c24c2d28e12ed2add7337f8becd60aa3148d16f5c3134af777c441320842c01b313814a80f0b7b8dc57c06c89a3ea5554e070591a8339db913a6175425f2bafb48d91a490de40c681132bf2123bbf53421d346264e7059c4d4bf4c6d91460bd50b22838bd1a408177b2ab9255d222d97730dd995d1e2f7cda505b3c58e58fbc629203ca4142632295838fdb2f47f7c099f5d8e414e0d0ca4ef791be651c175ecc3a88b68850e3b62b4bfffe94db76efbcfc175ecc3a88b68850e3b62b3b62b4bfffe94d";
+
+    for(int j = 1; j < 200; j+=5) {
+        std::set<CryptoKernel::BigNum> nums = {};
+        for(int i = 0; i < j; i++) {
+            nums.insert(CryptoKernel::BigNum(garbage.substr(i,24)));
+        }
+    
+        CryptoKernel::MerkleNode node = CryptoKernel::MerkleNode::makeMerkleTree(nums);
+
+        for(int i = 0; i < j; i++) {
+            CryptoKernel::BigNum val = CryptoKernel::BigNum(garbage.substr(i,24));
+            std::shared_ptr<CryptoKernel::MerkleProof> proof = node.makeProof(val);
+            std::shared_ptr<CryptoKernel::MerkleNode> proofNode = CryptoKernel::MerkleNode::makeMerkleTreeFromProof(proof);
+            CPPUNIT_ASSERT_EQUAL(node.getMerkleRoot().toString(), proofNode->getMerkleRoot().toString());
+        }
+    }
+}
+
+void MerkletreeTest::testProofSerialize() {
+    CryptoKernel::BigNum val = CryptoKernel::BigNum("aBc381023c383Def");
+    CryptoKernel::BigNum val2 = CryptoKernel::BigNum("bAc391045cEE3Dfe");
+    CryptoKernel::BigNum val3 = CryptoKernel::BigNum("cDc381023c383DbE");
+    CryptoKernel::BigNum val4 = CryptoKernel::BigNum("cAc391045cEE3DEE");
+    const std::set<CryptoKernel::BigNum> nums = {val, val2, val3, val4};
+
+    CryptoKernel::MerkleNode node = CryptoKernel::MerkleNode::makeMerkleTree(nums);
+    std::shared_ptr<CryptoKernel::MerkleProof> proof = node.makeProof(val3);
+
+    Json::StreamWriterBuilder builder;
+    builder["indentation"] = ""; // If you want whitespace-less output
+    const std::string output = Json::writeString(builder, proof->toJson());
+    
+    const std::string expectedOutput = "{\"leaves\":[\"cdc381023c383dbe\",\"cac391045cee3dee\",\"639d30b6811f703aac5a8296e4878e7ab6eeadf9b05e2821390ed0776bdd96be\",\"381529cb817f5faeee8131a2db231b938c6fbb80b6908bcded60edc87c4ed405\"],\"position\":3}";
+    CPPUNIT_ASSERT_EQUAL(output, expectedOutput);
+}
+
+void MerkletreeTest::testProofDeserialize() {
+    const std::string input = "{\"leaves\":[\"cdc381023c383dbe\",\"cac391045cee3dee\",\"639d30b6811f703aac5a8296e4878e7ab6eeadf9b05e2821390ed0776bdd96be\",\"381529cb817f5faeee8131a2db231b938c6fbb80b6908bcded60edc87c4ed405\"],\"position\":3}";
+    const std::string merkleRoot = "ce47e3721c8ce17cf3f81f131f39cd480ae12ca74e8955503a45a0595897b59a";
+
+    Json::Value inputJson;   
+    Json::CharReaderBuilder builder;
+    Json::CharReader* reader = builder.newCharReader();
+    std::string errors;
+    bool parsingSuccessful = reader->parse(
+        input.c_str(),
+        input.c_str() + input.size(),
+        &inputJson,
+        &errors
+    );
+    delete reader;
+
+    CPPUNIT_ASSERT(parsingSuccessful);
+    
+    std::shared_ptr<CryptoKernel::MerkleProof> proof = std::make_shared<CryptoKernel::MerkleProof>(inputJson);
+            
+    CPPUNIT_ASSERT_EQUAL(3, proof->positionInTotalSet);
+    CPPUNIT_ASSERT_EQUAL(CryptoKernel::BigNum("cdc381023c383dbe").toString(), proof->leaves.at(0).toString());
+
+    std::shared_ptr<CryptoKernel::MerkleNode> proofNode = CryptoKernel::MerkleNode::makeMerkleTreeFromProof(proof);
+
+    CPPUNIT_ASSERT_EQUAL(merkleRoot, proofNode->getMerkleRoot().toString());
+}
+
+void MerkletreeTest::testProofDeserializeInvalid() {
+    const std::string input = "{\"garbage\":1}";
+     Json::Value inputJson;   
+    Json::CharReaderBuilder builder;
+    Json::CharReader* reader = builder.newCharReader();
+    std::string errors;
+    bool parsingSuccessful = reader->parse(
+        input.c_str(),
+        input.c_str() + input.size(),
+        &inputJson,
+        &errors
+    );
+    delete reader;
+
+    CPPUNIT_ASSERT_THROW(std::make_shared<CryptoKernel::MerkleProof>(inputJson), CryptoKernel::Blockchain::InvalidElementException);
 }

--- a/tests/MerkletreeTests.cpp
+++ b/tests/MerkletreeTests.cpp
@@ -1,5 +1,4 @@
 #include "MerkletreeTests.h"
-#include <iostream>
 
 CPPUNIT_TEST_SUITE_REGISTRATION(MerkletreeTest);
 

--- a/tests/MerkletreeTests.h
+++ b/tests/MerkletreeTests.h
@@ -14,6 +14,11 @@ class MerkletreeTest : public CPPUNIT_NS::TestFixture {
     CPPUNIT_TEST(testMakeTreeFromPtr01);
     CPPUNIT_TEST(testMakeTreeFromPtr02);
     CPPUNIT_TEST(testMakeTreeFromLeaves);
+    CPPUNIT_TEST(testMakeProof);
+    CPPUNIT_TEST(testVerifyProof);
+    CPPUNIT_TEST(testProofSerialize);
+    CPPUNIT_TEST(testProofDeserialize);
+    CPPUNIT_TEST(testProofDeserializeInvalid);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -33,6 +38,11 @@ private:
     void testMakeTreeFromPtr01();
     void testMakeTreeFromPtr02();
     void testMakeTreeFromLeaves();
+    void testMakeProof();
+    void testVerifyProof();
+    void testProofSerialize();
+    void testProofDeserialize();
+    void testProofDeserializeInvalid();
 };
 
 #endif


### PR DESCRIPTION
In order to support the pay-to-merkletree effort, i needed the merkletree class to support building and verifying merkle proofs. 

I added this to the merkletree class, introduced two new classes:

- *MerkleProof* holds the proof data, and can serialize/deserialize them to and from Json

- *MerkleRootNode* can be initialized with a precomputed hash in case of reading a merkletree back from a proof - the nodes where the hash was calculated from are not availble, so the root value is just set from the constructor. LeftVal() and RightVal() will return empty.