### PR TITLE
Fixes Dockerfile for crash when running lua scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,6 @@ WORKDIR /app/bin
 COPY config.json /app/bin
 COPY peers.txt /app/bin 
 COPY genesisblock.json /app/bin 
-
+COPY *.lua /app/bin/
+RUN cp /usr/bin/lz4.so /app/bin/
 CMD ["/app/bin/ckd"]


### PR DESCRIPTION
When running ckd inside the docker container on K320, it crashed when it encountered a transaction utilizing lua. This PR fixes that.