### PR TITLE
Set node version when polling it for information

### DIFF
--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -309,6 +309,7 @@ void CryptoKernel::Network::infoOutgoingConnections() {
 						}
 					}
 
+                    it->second->setInfo("version", info["version"].asString());
 					it->second->setInfo("height", info["tipHeight"].asUInt64());
 
 					// update connected stats


### PR DESCRIPTION
This PR fixes a bug where the `version` field in `getpeerinfo` was blank.