### PR TITLE
Fix bug where the network stack would deadlock for certain errors

### DIFF
--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -374,10 +374,10 @@ void CryptoKernel::Network::networkFunc() {
         for(auto key : keys) {
         	auto it = connected.find(key);
         	if(it != connected.end() && it->second->acquire()) {
+                defer d([&]{it->second->release();});
         		if(it->second->getInfo("height").asUInt64() > bestHeight) {
 					bestHeight = it->second->getInfo("height").asUInt64();
 				}
-        		it->second->release();
         	}
         }
 
@@ -626,6 +626,7 @@ void CryptoKernel::Network::broadcastTransactions(const
 	for(std::string key : keys) {
 		auto it = connected.find(key);
 		if(it != connected.end() && it->second->acquire()) {
+            defer d([&]{it->second->release();});
 			try {
 				it->second->sendTransactions(transactions);
 			} catch(const Peer::NetworkError& err) {
@@ -641,12 +642,12 @@ void CryptoKernel::Network::broadcastBlock(const CryptoKernel::Blockchain::block
     for(std::string key : keys) {
     	auto it = connected.find(key);
     	if(it != connected.end() && it->second->acquire()) {
+            defer d([&]{it->second->release();});
     		try {
 				it->second->sendBlock(block);
 			} catch(const Peer::NetworkError& err) {
 				log->printf(LOG_LEVEL_WARN, "Network::broadcastBlock(): Failed to contact peer: " + std::string(err.what()));
 			}
-			it->second->release();
     	}
     }
 }

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -673,9 +673,7 @@ void CryptoKernel::Network::changeScore(const std::string& url, const uint64_t s
 
 std::set<std::string> CryptoKernel::Network::getConnectedPeers() {
     std::set<std::string> peerUrls;
-    std::vector<std::string> keys = connected.keys();
-    std::random_shuffle(keys.begin(), keys.end());
-    for(auto& peer : keys) {
+    for(const auto& peer : connected.keys()) {
     	peerUrls.insert(peer);
     }
 


### PR DESCRIPTION
The recent refactoring of the network stack left out some mutex releases that led to deadlocks under certain error conditions.