### PR TITLE
Build Lua as a DLL on Windows because that's required to import lz4

### DIFF
--- a/build/win64/Dockerfile
+++ b/build/win64/Dockerfile
@@ -84,8 +84,9 @@ WORKDIR ../
 RUN wget https://www.lua.org/ftp/lua-5.3.4.tar.gz && \
     tar xzvf lua-5.3.4.tar.gz
 WORKDIR lua-5.3.4
-RUN make generic CC="$CC -std=gnu99" AR="$AR rcu" && \
-    make local && cp -r install/* /usr/local/mingw
+RUN make mingw CC=$CC && \
+    cp src/lua53.dll /usr/local/mingw/lib/liblua.dll && \
+    cp src/*.h /usr/local/mingw/include/
 
 WORKDIR ../
 

--- a/build/win64/Dockerfile
+++ b/build/win64/Dockerfile
@@ -106,6 +106,7 @@ RUN wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha1
 COPY ./cryptokernel /cryptokernel
 
 RUN cp lua-lz4/lz4.dll cryptokernel
+RUN cp /usr/local/mingw/lib/liblua.dll cryptokernel/lua53.dll
 
 RUN git clone https://github.com/metalicjames/cschnorr.git
 WORKDIR cschnorr


### PR DESCRIPTION
This PR changes the release build procedure for Windows to produce a shared DLL for Lua instead of a static library. This should fix a bug where the Windows binaries could not load lz4 and thus were unable to decompress and validate transaction scripts.

Related to #52 which was a manifestation of the same issue on Linux.