### PR TITLE
Lock the connection while we are initialising it

### DIFF
--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -577,6 +577,8 @@ void CryptoKernel::Network::connectionFunc() {
                         "Network(): Peer connected from " + client->getRemoteAddress().toString() + ":" +
                         std::to_string(client->getRemotePort()));
             Connection* connection = new Connection();
+			connection->acquire();
+			defer d([&]{connection->release();});
             connection->setPeer(new Peer(client, blockchain, this, true));
 
             Json::Value info;
@@ -610,7 +612,6 @@ void CryptoKernel::Network::connectionFunc() {
             dbTx->commit();
         } else {
             delete client;
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
     }
 }


### PR DESCRIPTION
If a peer with a very small ping connected to `ckd` then the peer could become disconnected in another thread and the connection deleted before its initial info was committed to the database. That resulted in a segmentation fault in some cases where the connection was deleted in another thread and then subsequently used in the initialisation thread.  This PR locks the connection right after its creation and only releases it once the peer is fully set up. The PR also removes an unnecessary sleep call.

Fixes #57 