### PR TITLE
Set listener to blocking so the incoming connections loop does not busy wait

### DIFF
--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -157,8 +157,6 @@ CryptoKernel::Network::Network(CryptoKernel::Log* log,
 	memcpy(&seed, seedBuf, sizeof(seedBuf) / 8);
     std::srand(seed);
 
-    listener.setBlocking(false);
-
     // Start connection thread
     connectionThread.reset(new std::thread(&CryptoKernel::Network::connectionFunc, this));
 


### PR DESCRIPTION
The listener is in its own thread now so it should be blocking. Removing the sleep in #69 causes a busy wait without this change.