### PR TITLE
Functional is required for some platforms

### DIFF
--- a/src/kernel/network.h
+++ b/src/kernel/network.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <thread>
+#include <functional>
 
 #include <SFML/Network.hpp>
 


### PR DESCRIPTION
The dockerfile for the project requires the `functional` header in order to use an `std::function`