### PR TITLE
Only re-add the utxo to the wallet database if it has a publicKey we own

### DIFF
--- a/src/client/wallet.cpp
+++ b/src/client/wallet.cpp
@@ -261,9 +261,10 @@ void CryptoKernel::Wallet::rewindTx(const CryptoKernel::Blockchain::transaction&
                 } catch(const WalletException& e) {
                     continue;
                 }
+
+                const Txo newTxo = Txo(out.getId().toString(), out.getValue());
+                utxos->put(walletTx, out.getId().toString(), newTxo.toJson());
             }
-            const Txo newTxo = Txo(out.getId().toString(), out.getValue());
-            utxos->put(walletTx, out.getId().toString(), newTxo.toJson());
         }
     }
 }


### PR DESCRIPTION
When re-winding transactions in the case of a re-org in the wallet we re-added the utxos of inputs to the database if we were tracking the transaction, irrespective of whether the output contained a pubkey we owned. This could lead to a crash when the wallet is digesting blocks after a re-org as it tries to lookup a public key the wallet doesn't have.