### PR TITLE
Add RPC for signing an arbitrary string with a given public key

### DIFF
--- a/src/client/cryptoserver.h
+++ b/src/client/cryptoserver.h
@@ -82,6 +82,10 @@ public:
         this->bindAndAddMethod(jsonrpc::Procedure("getoutputsetid", jsonrpc::PARAMS_BY_NAME,
                                jsonrpc::JSON_STRING, "outputs", jsonrpc::JSON_ARRAY,
                                NULL), &CryptoRPCServer::getoutputsetidI);
+        this->bindAndAddMethod(jsonrpc::Procedure("signmessage", jsonrpc::PARAMS_BY_NAME,
+                               jsonrpc::JSON_STRING, "message",jsonrpc::JSON_STRING, 
+                               "password", jsonrpc::JSON_STRING, "publickey", jsonrpc::JSON_STRING, NULL),
+                                                  &CryptoRPCServer::signmessageI);
     }
 
     inline virtual void getinfoI(const Json::Value &request, Json::Value &response) {
@@ -149,6 +153,10 @@ public:
     inline virtual void getoutputsetidI(const Json::Value &request, Json::Value &response) {
         response = this->getoutputsetid(request["outputs"]);
     }
+    inline virtual void signmessageI(const Json::Value &request, Json::Value &response) {
+        response = this->signmessage(request["message"].asString(), request["publickey"].asString(),  
+                                         request["password"].asString());
+    }
     virtual Json::Value getinfo() = 0;
     virtual Json::Value account(const std::string& account, const std::string& password) = 0;
     virtual std::string sendtoaddress(const std::string& address, double amount,
@@ -171,6 +179,7 @@ public:
     virtual Json::Value getpeerinfo() = 0;
     virtual Json::Value dumpprivkeys(const std::string& account, const std::string& password) = 0;
     virtual std::string getoutputsetid(const Json::Value& outputs) = 0;
+    virtual std::string signmessage(const std::string& message, const std::string& publickey, const std::string& password) = 0;
 };
 
 class CryptoServer : public CryptoRPCServer {
@@ -201,6 +210,7 @@ public:
     virtual Json::Value getpeerinfo();
     virtual Json::Value dumpprivkeys(const std::string& account, const std::string& password);
     virtual std::string getoutputsetid(const Json::Value& outputs);
+    virtual std::string signmessage(const std::string& message, const std::string& publickey, const std::string& password);
 
 private:
     CryptoKernel::Wallet* wallet;

--- a/src/client/rpcserver.cpp
+++ b/src/client/rpcserver.cpp
@@ -384,3 +384,17 @@ std::string CryptoServer::getoutputsetid(const Json::Value& outputs) {
     return CryptoKernel::MerkleNode::makeMerkleTree(outputIds)->getMerkleRoot()
            .toString();
 }
+
+std::string CryptoServer::signmessage(const std::string& message,
+                                      const std::string& publickey,
+                                      const std::string& password) {
+    if(wallet != nullptr) {
+        try {
+            return wallet->signMessage(message, publickey, password);
+        } catch(const CryptoKernel::Wallet::WalletException& e) {
+            return e.what();
+        }
+    } else {
+        return noWalletError;
+    }
+}

--- a/src/client/wallet.cpp
+++ b/src/client/wallet.cpp
@@ -776,6 +776,32 @@ std::tuple<std::set<CryptoKernel::Blockchain::transaction>, std::set<CryptoKerne
     return returning;
 }
 
+std::string CryptoKernel::Wallet::signMessage(const std::string& message,
+                                              const std::string& publicKey,
+                                              const std::string& password) {
+    std::lock_guard<std::recursive_mutex> lock(walletLock);
+
+    if(!checkPassword(password)) {
+        throw WalletException("Incorrect wallet password");
+    }
+
+    const Account acc = getAccountByKey(publicKey);
+    
+    std::string privKey;
+
+    for(const auto& key : acc.getKeys()) {
+        if(key.pubKey == publicKey) {
+            privKey = key.privKey->decrypt(password);
+            break;
+        }
+    }
+
+    CryptoKernel::Crypto crypto;
+    crypto.setPrivateKey(privKey);
+
+    return crypto.sign(message);
+}
+
 CryptoKernel::Blockchain::transaction
 CryptoKernel::Wallet::signTransaction(const CryptoKernel::Blockchain::transaction& tx,
                                       const std::string& password) {

--- a/src/client/wallet.h
+++ b/src/client/wallet.h
@@ -132,6 +132,10 @@ public:
     CryptoKernel::Blockchain::transaction signTransaction(const
             CryptoKernel::Blockchain::transaction& tx, const std::string& password);
 
+    std::string signMessage(const std::string& message,
+                            const std::string& publicKey,
+                            const std::string& password);
+
 private:
     std::unique_ptr<CryptoKernel::Storage> walletdb;
     std::unique_ptr<CryptoKernel::Storage::Table> accounts;


### PR DESCRIPTION
This PR adds the `signmessage` RPC to `ckd`. Given a string and a public key for which the private key is stored in the wallet the RPC returns the signature for the message that will verify with the given public key.