### PR TITLE
Only return if all contract outputs have been checked successfully

### DIFF
--- a/src/kernel/blockchain.cpp
+++ b/src/kernel/blockchain.cpp
@@ -495,25 +495,19 @@ std::tuple<bool, bool> CryptoKernel::Blockchain::verifyTransaction(Storage::Tran
         }
     }
 
-    std::cout << "Starting contractrunner" << std::endl;
-
     CryptoKernel::ContractRunner lvm(this);
     if(!lvm.evaluateValid(dbTransaction, tx)) {
-        std::cout << "Script returned false" << std::endl;
-
         log->printf(LOG_LEVEL_INFO, "blockchain::verifyTransaction(): Script returned false");
         return std::make_tuple(false, true);
     }
 
     if(!consensus->verifyTransaction(dbTransaction, tx)) {
-        std::cout << "Custom rules failed" << std::endl;
-
         log->printf(LOG_LEVEL_INFO,
                     "blockchain::verifyTransaction(): Could not verify custom rules");
         return std::make_tuple(false, true);
     }
 
-    log->printf(LOG_LEVEL_INFO, "blockchain::verifyTransaction(): Verified succesfully");
+    log->printf(LOG_LEVEL_INFO, "blockchain::verifyTransaction(): Verified successfully");
        
     return std::make_tuple(true, false);
 }

--- a/src/kernel/contract.cpp
+++ b/src/kernel/contract.cpp
@@ -107,7 +107,9 @@ bool CryptoKernel::ContractRunner::evaluateValid(Storage::Transaction* dbTx,
                     blockchain->utxos->get(dbTx, inp.getOutputId().toString()));
         const Json::Value data = out.getData();
         if(!data["contract"].empty()) {
-            return this->evaluateScriptValid(dbTx, tx, inp, data["contract"].asString());
+            if(!this->evaluateScriptValid(dbTx, tx, inp, data["contract"].asString())) {
+                return false;
+            }
         }
     }
 

--- a/tests/ContractTests.cpp
+++ b/tests/ContractTests.cpp
@@ -72,7 +72,6 @@ void ContractTest::testSimpleFail() {
 
     consensus->mineBlock(true, ECDSAPubKey);
 
-
     // Try spending from the contract output back to our key. Should fail as the script is just 'return false'
     Json::Value p2pkOutData;
     p2pkOutData["publicKey"] = crypto.getPublicKey();
@@ -117,8 +116,6 @@ void ContractTest::testHelloWorld() {
 
     consensus->mineBlock(true, ECDSAPubKey);
 
-    std::cout << "Spending from contract output (wrong preimage)" << std::endl;
-
     // Try spending from the contract output back to our key. First try with invalid preimage. Should fail
     Json::Value p2pkOutData;
     p2pkOutData["publicKey"] = crypto.getPublicKey();
@@ -132,8 +129,6 @@ void ContractTest::testHelloWorld() {
     const auto res2 = blockchain->submitTransaction(contractspendtx);
     CPPUNIT_ASSERT_MESSAGE("Spending contract output succeeded. Shouldn't have.", !std::get<0>(res2));
 
-    std::cout << "Spending from contract output (correct preimage)" << std::endl;
-
     // Try spending from the contract output back to our key. Try with correct preimage. Should succeed
     Json::Value spendData3; // empty
     spendData3["preimage"] = "Hello, World";
@@ -141,7 +136,56 @@ void ContractTest::testHelloWorld() {
     CryptoKernel::Blockchain::transaction contractspendtx2({contractin2}, {p2pkout}, 1530888581);
 
     const auto res3 = blockchain->submitTransaction(contractspendtx2);
-    CPPUNIT_ASSERT_MESSAGE("Spending contract output failed", std::get<0>(res3));
+    CPPUNIT_ASSERT_MESSAGE("Spending contract output failed", std::get<0>(res3));  
+}
 
+void ContractTest::testTwoContractInputs() {
+    CryptoKernel::Crypto crypto(true);
+    const auto ECDSAPubKey = crypto.getPublicKey();
+
+    consensus->mineBlock(true, ECDSAPubKey);
+
+    const auto outs = blockchain->getUnspentOutputs(ECDSAPubKey);
+    const auto& out = *outs.begin();
+
+    // First, spend our newly acquired coinbase output to
+    // a pay-to-merkleroot output
+    Json::Value outData;
     
+    // "sha256(preimage) = sha(hello world)"
+    outData["contract"] = "BCJNGGBAggEBAAD2BRtMdWFTABmTDQoaCgQIBAgIeFYAAQD1aCh3QAFzcmV0dXJuIHNoYTI1Nih0aGlzSW5wdXRbImRhdGEiXVsicHJlaW1hZ2UiXSkgPT0gIjAzNjc1YWM1M2ZmOWNkMTUzNWNjYzdkZmNkZmEyYzQ1OGM1MjE4MzcxZjQxOGRjMTM2ZjJkMTlhYzFmYmU4YTUigADyKQICCwAAAAYAQABGQEAAR4DAAEfAwAAkgAABXwBBAB4AAIADQAAAAwCAACYAAAEmAIAABQAAAAQHrAAlBAqtACAEBa0AJAQJqwAvFEGlAC1RAQAAAAGlABMLCgAPBAAVAAEAkAEAAAAFX0VOVgAAAAA="; 
+    
+    CryptoKernel::Blockchain::output contractOutput1((out.getValue() / 2) - 90000, 0, outData);
+    CryptoKernel::Blockchain::output contractOutput2((out.getValue() / 2) - 90000, 1, outData);
+
+    const std::string outputSetId = CryptoKernel::Blockchain::transaction::getOutputSetId({contractOutput1, contractOutput2}).toString();
+
+    Json::Value spendData;
+    spendData["signature"] = crypto.sign(out.getId().toString() + outputSetId);
+
+    CryptoKernel::Blockchain::input inp(out.getId(), spendData);
+    CryptoKernel::Blockchain::transaction tx({inp}, {contractOutput1, contractOutput2}, 1530888581);
+
+    const auto res = blockchain->submitTransaction(tx);
+    CPPUNIT_ASSERT_MESSAGE("Initial contract transaction failed", std::get<0>(res));
+
+    consensus->mineBlock(true, ECDSAPubKey);
+
+    // Try spending from the contract output back to our key. First try with invalid preimage. Should fail
+    Json::Value p2pkOutData;
+    p2pkOutData["publicKey"] = crypto.getPublicKey();
+    CryptoKernel::Blockchain::output p2pkout((contractOutput1.getValue() * 2) - 40000, 0, p2pkOutData);
+
+    Json::Value spendDataFail; 
+    spendDataFail["preimage"] = "Hello world FAIL";
+
+    Json::Value spendDataSucceed;
+    spendDataSucceed["preimage"] = "Hello, World";
+
+    CryptoKernel::Blockchain::input contractin1(contractOutput1.getId(), spendDataSucceed);
+    CryptoKernel::Blockchain::input contractin2(contractOutput2.getId(), spendDataFail);
+    CryptoKernel::Blockchain::transaction contractspendtx({contractin1, contractin2}, {p2pkout}, 1530888581);
+
+    const auto res2 = blockchain->submitTransaction(contractspendtx);
+    CPPUNIT_ASSERT_MESSAGE("Spending contract output succeeded. Shouldn't have.", !std::get<0>(res2));
 }

--- a/tests/ContractTests.h
+++ b/tests/ContractTests.h
@@ -11,6 +11,7 @@ class ContractTest : public CPPUNIT_NS::TestFixture {
 
     CPPUNIT_TEST(testSimpleFail);
     CPPUNIT_TEST(testHelloWorld);
+    CPPUNIT_TEST(testTwoContractInputs);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -31,6 +32,7 @@ private:
 
     void testSimpleFail();
     void testHelloWorld();
+    void testTwoContractInputs();
 
     std::unique_ptr<CryptoKernel::Blockchain> blockchain;
     std::unique_ptr<CryptoKernel::Log> log;


### PR DESCRIPTION
Also added a regression test for this and cleaned up some leftover `cout` calls