### PR TITLE
Network encryption

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -36,7 +36,7 @@ workspace "CryptoKernel"
 
 cklibs = {"crypto", "sfml-network", 
 "sfml-system", "leveldb", "jsoncpp", "jsonrpccpp-server", 
-"jsonrpccpp-client", "jsonrpccpp-common", "microhttpd", "cschnorr"}
+"jsonrpccpp-client", "jsonrpccpp-common", "microhttpd", "cschnorr", "noiseprotocol"}
 
 linuxLinks = {"pthread", "lua5.3", "curl", "dl", "gcov"}
 

--- a/src/kernel/NoiseClient.cpp
+++ b/src/kernel/NoiseClient.cpp
@@ -327,4 +327,5 @@ NoiseClient::~NoiseClient() {
 		setHandshakeComplete(true, false);
 	}
 	writeInfoThread->join();
+	receiveThread->join();
 }

--- a/src/kernel/NoiseClient.cpp
+++ b/src/kernel/NoiseClient.cpp
@@ -221,6 +221,7 @@ void NoiseClient::receiveWrapper() {
 			else {
 				log->printf(LOG_LEVEL_INFO, "Noise(): Client encountered error receiving packet " + server->getRemoteAddress().toString());
 				quitThread = true;
+				setHandshakeComplete(true, false);
 			}
 		}
 	}

--- a/src/kernel/NoiseClient.cpp
+++ b/src/kernel/NoiseClient.cpp
@@ -160,6 +160,9 @@ void NoiseClient::writeInfo() {
 					ok = 0;
 					continue;
 				}
+				else {
+					log->printf(LOG_LEVEL_INFO, "Noise(): Client successfully sent packet to " + server->getRemoteAddress().toString());
+				}
 			}
 			else if(action != NOISE_ACTION_READ_MESSAGE) {
 				log->printf(LOG_LEVEL_INFO, "Noise(): Client, either the handshake succeeded, or it failed");

--- a/src/kernel/NoiseClient.cpp
+++ b/src/kernel/NoiseClient.cpp
@@ -208,12 +208,12 @@ void NoiseClient::receiveWrapper() {
     log->printf(LOG_LEVEL_INFO, "Noise(): Client, receive wrapper starting. " + server->getRemoteAddress().toString());
     bool quitThread = false;
 
-	/*sf::SocketSelector selector;
-	selector.add(*server);*/
+	sf::SocketSelector selector;
+	selector.add(*server);
 
     while(!quitThread && !getHandshakeComplete()) {
-		/*if(selector.wait(sf::seconds(1))) {
-			sf::Packet packet;*/
+		if(selector.wait(sf::seconds(1))) {
+			sf::Packet packet;
 			const auto status = server->receive(packet);
 			if(status == sf::Socket::Done) {
 				receivePacket(packet);
@@ -222,11 +222,11 @@ void NoiseClient::receiveWrapper() {
 				log->printf(LOG_LEVEL_INFO, "Noise(): Client encountered error receiving packet " + server->getRemoteAddress().toString());
 				quitThread = true;
 				setHandshakeComplete(true, false);
-			/*}
-		}*/
+			}
+		}
 	}
 
-	//selector.remove(*server);
+	selector.remove(*server);
 }
 
 void NoiseClient::receivePacket(sf::Packet& packet) {

--- a/src/kernel/NoiseClient.cpp
+++ b/src/kernel/NoiseClient.cpp
@@ -207,7 +207,7 @@ void NoiseClient::receiveWrapper() {
     selector.add(*server.get());
     bool quitThread = false;
 
-    while(!quitThread)
+    while(!quitThread && !getHandshakeComplete())
     if(selector.wait(sf::seconds(2))) {
         sf::Packet packet;
         const auto status = server->receive(packet);

--- a/src/kernel/NoiseClient.cpp
+++ b/src/kernel/NoiseClient.cpp
@@ -1,0 +1,309 @@
+/*
+ * Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "NoiseClient.h"
+#include <unistd.h>
+#include <stdlib.h>
+
+NoiseClient::NoiseClient(std::shared_ptr<sf::TcpSocket> server, std::string ipAddress, uint64_t port, CryptoKernel::Log* log) {
+	this->server = server;
+	this->log = log;
+	this->ipAddress = ipAddress;
+	this->port = port;
+
+	clientPrivateKey = "keys/client_key_25519";
+
+	send_cipher = 0;
+	recv_cipher = 0;
+
+	sentId = false;
+
+	handshakeComplete = false;
+	handshakeSuccess = false;
+
+	log->printf(LOG_LEVEL_INFO, "Noise(): Client started");
+
+	if(noise_init() != NOISE_ERROR_NONE) {
+		log->printf(LOG_LEVEL_WARN, "Noise initialization failed");
+		return;
+	}
+
+	std::string protocol = "Noise_XX_25519_AESGCM_SHA256";
+	prologue.pattern = PATTERN_XX;
+	prologue.psk = PSK_DISABLED;
+	prologue.cipher = CIPHER_AESGCM;
+	prologue.hash = HASH_SHA256;
+	prologue.dh = DH_25519;
+
+	/* Create a HandshakeState object for the protocol */
+	int err = noise_handshakestate_new_by_name(&handshake, protocol.c_str(), NOISE_ROLE_INITIATOR);
+	if(err != NOISE_ERROR_NONE) {
+		log->printf(LOG_LEVEL_WARN, "Client, error: " + noiseUtil.errToString(err));
+		return;
+	}
+
+	log->printf(LOG_LEVEL_INFO, "Noise(): Client, starting writeInfo.");
+	writeInfoThread.reset(new std::thread(&NoiseClient::writeInfo, this)); // start the write info thread
+}
+
+void NoiseClient::writeInfo() {
+	log->printf(LOG_LEVEL_INFO, "Noise(): Client writing info");
+
+	int action;
+	NoiseBuffer mbuf;
+	int err, ok;
+	size_t message_size;
+
+	uint8_t message[MAX_MESSAGE_LEN + 2];
+
+	ok = 1;
+
+	bool sentPubKey = false;
+
+	while(!getHandshakeComplete()) { // it might fail in another thread, and so become "complete"
+		if(server->getRemoteAddress() == sf::IpAddress::None) {
+			log->printf(LOG_LEVEL_WARN, "Noise(): Client, the remote port has been invalidated");
+			setHandshakeComplete(true, false);
+			ok = 0;
+			continue;
+		}
+
+		if(!sentPubKey) { // we need to share our public key over the network
+			log->printf(LOG_LEVEL_INFO, "Noise(): Client sending public key to " + server->getRemoteAddress().toString());
+			sf::Packet pubKeyPacket;
+			if(!noiseUtil.loadPublicKey("keys/client_key_25519.pub", clientKey25519, sizeof(clientKey25519))) {
+				uint8_t* privKey = 0;
+				uint8_t* pubKey = 0;
+				if(!noiseUtil.writeKeys("keys/client_key_25519.pub", "keys/client_key_25519", &pubKey, &privKey)) {
+					setHandshakeComplete(true, false);
+					ok = 0;
+					delete pubKey;
+					delete privKey;
+					continue;
+				}
+				memcpy(clientKey25519, pubKey, CURVE25519_KEY_LEN); // put the new key in its proper place
+				delete pubKey;
+				delete privKey;
+			}
+
+			handshakeMutex.lock();
+			if(!initializeHandshake(handshake, &prologue, sizeof(prologue))) { // now that we have keys, initialize handshake
+				log->printf(LOG_LEVEL_WARN, "Noise(): Client, error initializing handshake.");
+				ok = 0;
+				handshakeMutex.unlock();
+				setHandshakeComplete(true, false);
+				continue;
+			}
+			handshakeMutex.unlock();
+
+			pubKeyPacket.append(clientKey25519, sizeof(clientKey25519));
+
+			if(server->send(pubKeyPacket) != sf::Socket::Done) {
+				continue; // keep sending the public key until it goes through
+			}
+
+			sentPubKey = true;
+			err = noise_handshakestate_start(handshake);
+			if(err != NOISE_ERROR_NONE) {
+				log->printf(LOG_LEVEL_WARN, "Noise(): Client start handshake error, " + noiseUtil.errToString(err));
+				setHandshakeComplete(true, false);
+				ok = 0;
+				continue;
+			}
+		}
+		else {
+			handshakeMutex.lock();
+			action = noise_handshakestate_get_action(handshake);
+			handshakeMutex.unlock();
+
+			if(action == NOISE_ACTION_WRITE_MESSAGE) {
+				/* Write the next handshake message with a zero-length payload */
+				noise_buffer_set_output(mbuf, message + 2, sizeof(message) - 2);
+				handshakeMutex.lock();
+				err = noise_handshakestate_write_message(handshake, &mbuf, NULL);
+				handshakeMutex.unlock();
+				if(err != NOISE_ERROR_NONE) {
+					log->printf(LOG_LEVEL_WARN, "Noise(): Client, handshake failed on write message: " + noiseUtil.errToString(err));
+					setHandshakeComplete(true, false);
+					ok = 0;
+					continue;
+				}
+				message[0] = (uint8_t)(mbuf.size >> 8);
+				message[1] = (uint8_t)mbuf.size;
+
+				log->printf(LOG_LEVEL_INFO, "Noise(): Client sending a packet.");
+				sf::Packet packet;
+				packet.append(message, mbuf.size + 2);
+				if(server->send(packet) != sf::Socket::Done) {
+					log->printf(LOG_LEVEL_WARN, "Noise(): Client couldn't send packet.");
+					setHandshakeComplete(true, false);
+					ok = 0;
+					continue;
+				}
+			}
+			else if(action != NOISE_ACTION_READ_MESSAGE) {
+				log->printf(LOG_LEVEL_INFO, "Noise(): Client, either the handshake succeeded, or it failed");
+				break;
+			}
+		}
+
+		std::this_thread::sleep_for(std::chrono::milliseconds(50)); // again, totally arbitrary
+	}
+
+	/* If the action is not "split", then the handshake has failed */
+	handshakeMutex.lock();
+	if(ok && noise_handshakestate_get_action(handshake) != NOISE_ACTION_SPLIT) {
+		log->printf(LOG_LEVEL_WARN, "Noise(): Client, protocol handshake failed");
+		ok = 0;
+	}
+	handshakeMutex.unlock();
+
+	/* Split out the two CipherState objects for send and receive */
+	if(ok) {
+		handshakeMutex.lock();
+		err = noise_handshakestate_split(handshake, &send_cipher, &recv_cipher);
+		handshakeMutex.unlock();
+		if(err != NOISE_ERROR_NONE) {
+			log->printf(LOG_LEVEL_WARN, "Noise(): Client, split failed: " + noiseUtil.errToString(err));
+			ok = 0;
+		}
+	}
+
+	/* We no longer need the HandshakeState */
+	handshakeMutex.lock();
+	noise_handshakestate_free(handshake);
+	handshakeMutex.unlock();
+	handshake = 0;
+
+	// padding would go here, if we used it
+
+	/* Tell the user that the handshake has been successful */
+	setHandshakeComplete(true, ok);
+}
+
+void NoiseClient::receivePacket(sf::Packet packet) {
+	log->printf(LOG_LEVEL_INFO, "Noise(): Client receiving a packet.");
+
+	handshakeMutex.lock();
+	int action = noise_handshakestate_get_action(handshake);
+	handshakeMutex.unlock();
+	NoiseBuffer mbuf;
+	int err, ok;
+	size_t message_size;
+
+	uint8_t message[MAX_MESSAGE_LEN + 2];
+
+	if(action == NOISE_ACTION_READ_MESSAGE) {
+		log->printf(LOG_LEVEL_INFO, "Noise(): Client reading a message.");
+
+		message_size = packet.getDataSize();
+		memcpy(message, packet.getData(), packet.getDataSize());
+
+		noise_buffer_set_input(mbuf, message + 2, message_size - 2);
+		handshakeMutex.lock();
+		err = noise_handshakestate_read_message(handshake, &mbuf, NULL);
+		handshakeMutex.unlock();
+		if(err != NOISE_ERROR_NONE) {
+			log->printf(LOG_LEVEL_WARN, "Noise(): Client, read handshake " + noiseUtil.errToString(err));
+			setHandshakeComplete(true, false);
+		}
+	}
+}
+
+void NoiseClient::setHandshakeComplete(bool complete, bool success) {
+	if(success) {
+		log->printf(LOG_LEVEL_INFO, "Noise(): Client handshake succeeded");
+	}
+
+	std::lock_guard<std::mutex> hcm(handshakeCompleteMutex);
+	handshakeComplete = complete;
+	handshakeSuccess = success;
+}
+
+bool NoiseClient::getHandshakeComplete() {
+	std::lock_guard<std::mutex> hcm(handshakeCompleteMutex);
+	return handshakeComplete;
+}
+
+bool NoiseClient::getHandshakeSuccess() {
+	std::lock_guard<std::mutex> hcm(handshakeCompleteMutex);
+	return handshakeSuccess;
+}
+
+/* Initialize's the handshake using command-line options */
+int NoiseClient::initializeHandshake(NoiseHandshakeState* handshake, const void* prologue, size_t prologue_len) {
+	NoiseDHState *dh;
+	uint8_t *key = 0;
+	size_t keyLen = 0;
+	int err;
+
+	/* Set the prologue first */
+	err = noise_handshakestate_set_prologue(handshake, prologue, prologue_len);
+	if(err != NOISE_ERROR_NONE) {
+		log->printf(LOG_LEVEL_INFO, "Noise(): Client prologue: " + noiseUtil.errToString(err));
+		return 0;
+	}
+
+	// we are not using pre-shared keys, but they would be initialized right here
+
+	/* Set the local keypair for the client */
+	if(noise_handshakestate_needs_local_keypair(handshake)) {
+		if(clientPrivateKey.length() > 0) {
+			dh = noise_handshakestate_get_local_keypair_dh(handshake);
+			keyLen = noise_dhstate_get_private_key_length(dh);
+			key = (uint8_t*)malloc(keyLen);
+			if(!key) {
+				log->printf(LOG_LEVEL_INFO, "Noise(): Client, could not allocate space for key.");
+				return 0;
+			}
+			if(!noiseUtil.loadPrivateKey(clientPrivateKey.c_str(), key, keyLen)) {
+				log->printf(LOG_LEVEL_WARN, "Noise(): Client, could not load private key.");
+				noise_free(key, keyLen);
+				return 0;
+			}
+			err = noise_dhstate_set_keypair_private(dh, key, keyLen);
+			noise_free(key, keyLen);
+			if(err != NOISE_ERROR_NONE) {
+				log->printf(LOG_LEVEL_WARN, "Noise(): Set client private key " + noiseUtil.errToString(err));
+				return 0;
+			}
+		}
+		else {
+			log->printf(LOG_LEVEL_WARN, "Noise(): Client private key required but not provided.");
+			return 0;
+		}
+	}
+
+	// we are not using a remote public key for the server, but it would be initialized right here
+
+	/* Ready to go */
+	log->printf(LOG_LEVEL_INFO, "Noise(): Client handshake initialization successful!");
+	return 1;
+}
+
+NoiseClient::~NoiseClient() {
+	log->printf(LOG_LEVEL_INFO, "Cleaning up noise client");
+	if(!getHandshakeComplete()) {
+		setHandshakeComplete(true, false);
+	}
+	writeInfoThread->join();
+}

--- a/src/kernel/NoiseClient.cpp
+++ b/src/kernel/NoiseClient.cpp
@@ -254,7 +254,7 @@ void NoiseClient::setHandshakeComplete(bool complete, bool success) {
 	if(success) {
 		log->printf(LOG_LEVEL_INFO, "Noise(): Client handshake succeeded");
 	}
-
+	
 	std::lock_guard<std::mutex> hcm(handshakeCompleteMutex);
 	handshakeComplete = complete;
 	handshakeSuccess = success;
@@ -326,6 +326,7 @@ NoiseClient::~NoiseClient() {
 	if(!getHandshakeComplete()) {
 		setHandshakeComplete(true, false);
 	}
+	server->disconnect();
 	writeInfoThread->join();
 	receiveThread->join();
 	log->printf(LOG_LEVEL_INFO, "Cleaned up noise client");

--- a/src/kernel/NoiseClient.cpp
+++ b/src/kernel/NoiseClient.cpp
@@ -24,7 +24,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 
-NoiseClient::NoiseClient(std::shared_ptr<sf::TcpSocket> server, std::string ipAddress, uint64_t port, CryptoKernel::Log* log) {
+NoiseClient::NoiseClient(sf::TcpSocket* server, std::string ipAddress, uint64_t port, CryptoKernel::Log* log) {
 	this->server = server;
 	this->log = log;
 	this->ipAddress = ipAddress;
@@ -204,7 +204,7 @@ void NoiseClient::writeInfo() {
 void NoiseClient::receiveWrapper() {
     log->printf(LOG_LEVEL_INFO, "Noise(): Client, receive wrapper starting.");
     sf::SocketSelector selector;
-    selector.add(*server.get());
+    selector.add(*server);
     bool quitThread = false;
 
     while(!quitThread && !getHandshakeComplete())
@@ -219,6 +219,8 @@ void NoiseClient::receiveWrapper() {
             quitThread = true;
         }
     }
+
+	selector.remove(*server);
 }
 
 void NoiseClient::receivePacket(sf::Packet& packet) {
@@ -327,6 +329,7 @@ NoiseClient::~NoiseClient() {
 		setHandshakeComplete(true, false);
 	}
 	server->disconnect();
+	delete server;
 	writeInfoThread->join();
 	receiveThread->join();
 	log->printf(LOG_LEVEL_INFO, "Cleaned up noise client");

--- a/src/kernel/NoiseClient.cpp
+++ b/src/kernel/NoiseClient.cpp
@@ -208,10 +208,10 @@ void NoiseClient::receiveWrapper() {
     log->printf(LOG_LEVEL_INFO, "Noise(): Client, receive wrapper starting. " + server->getRemoteAddress().toString());
     bool quitThread = false;
 
-    while(!quitThread && !getHandshakeComplete()) {
-		sf::SocketSelector selector;
-    	selector.add(*server);
+	sf::SocketSelector selector;
+	selector.add(*server);
 
+    while(!quitThread && !getHandshakeComplete()) {
 		if(selector.wait(sf::seconds(1))) {
 			sf::Packet packet;
 			const auto status = server->receive(packet);
@@ -224,6 +224,8 @@ void NoiseClient::receiveWrapper() {
 			}
 		}
 	}
+
+	selector.remove(*server);
 }
 
 void NoiseClient::receivePacket(sf::Packet& packet) {

--- a/src/kernel/NoiseClient.cpp
+++ b/src/kernel/NoiseClient.cpp
@@ -328,4 +328,5 @@ NoiseClient::~NoiseClient() {
 	}
 	writeInfoThread->join();
 	receiveThread->join();
+	log->printf(LOG_LEVEL_INFO, "Cleaned up noise client");
 }

--- a/src/kernel/NoiseClient.cpp
+++ b/src/kernel/NoiseClient.cpp
@@ -30,6 +30,8 @@ NoiseClient::NoiseClient(sf::TcpSocket* server, CryptoKernel::Log* log) {
 	this->ipAddress = ipAddress;
 	this->port = port;
 
+	addr = server->getRemoteAddress().toString();
+
 	clientPrivateKey = "keys/client_key_25519";
 
 	send_cipher = 0;
@@ -65,8 +67,6 @@ NoiseClient::NoiseClient(sf::TcpSocket* server, CryptoKernel::Log* log) {
 }
 
 void NoiseClient::writeInfo() {
-	log->printf(LOG_LEVEL_INFO, "Noise(): Client (of " + addr + ") writing info.");
-
 	int action;
 	NoiseBuffer mbuf;
 	int err, ok;
@@ -115,7 +115,7 @@ void NoiseClient::writeInfo() {
 
 			pubKeyPacket.append(clientKey25519, sizeof(clientKey25519));
 
-			if(server->send(pubKeyPacket) != sf::Socket::Done) {
+			if(server->send(pubKeyPacket) != sf::Socket::Done) { // not useful right now, but could be if we go non-blocking
 				continue; // keep sending the public key until it goes through
 			}
 

--- a/src/kernel/NoiseClient.cpp
+++ b/src/kernel/NoiseClient.cpp
@@ -208,12 +208,12 @@ void NoiseClient::receiveWrapper() {
     log->printf(LOG_LEVEL_INFO, "Noise(): Client, receive wrapper starting. " + server->getRemoteAddress().toString());
     bool quitThread = false;
 
-	sf::SocketSelector selector;
-	selector.add(*server);
+	/*sf::SocketSelector selector;
+	selector.add(*server);*/
 
     while(!quitThread && !getHandshakeComplete()) {
-		if(selector.wait(sf::seconds(1))) {
-			sf::Packet packet;
+		/*if(selector.wait(sf::seconds(1))) {
+			sf::Packet packet;*/
 			const auto status = server->receive(packet);
 			if(status == sf::Socket::Done) {
 				receivePacket(packet);
@@ -222,11 +222,11 @@ void NoiseClient::receiveWrapper() {
 				log->printf(LOG_LEVEL_INFO, "Noise(): Client encountered error receiving packet " + server->getRemoteAddress().toString());
 				quitThread = true;
 				setHandshakeComplete(true, false);
-			}
-		}
+			/*}
+		}*/
 	}
 
-	selector.remove(*server);
+	//selector.remove(*server);
 }
 
 void NoiseClient::receivePacket(sf::Packet& packet) {

--- a/src/kernel/NoiseClient.cpp
+++ b/src/kernel/NoiseClient.cpp
@@ -206,24 +206,24 @@ void NoiseClient::writeInfo() {
 
 void NoiseClient::receiveWrapper() {
     log->printf(LOG_LEVEL_INFO, "Noise(): Client, receive wrapper starting. " + server->getRemoteAddress().toString());
-    sf::SocketSelector selector;
-    selector.add(*server);
     bool quitThread = false;
 
-    while(!quitThread && !getHandshakeComplete())
-    if(selector.wait(sf::seconds(2))) {
-        sf::Packet packet;
-        const auto status = server->receive(packet);
-        if(status == sf::Socket::Done) {
-            receivePacket(packet);
-        }
-        else {
-            log->printf(LOG_LEVEL_INFO, "Noise(): Client encountered error receiving packet " + server->getRemoteAddress().toString());
-            quitThread = true;
-        }
-    }
+    while(!quitThread && !getHandshakeComplete()) {
+		sf::SocketSelector selector;
+    	selector.add(*server);
 
-	selector.remove(*server);
+		if(selector.wait(sf::seconds(1))) {
+			sf::Packet packet;
+			const auto status = server->receive(packet);
+			if(status == sf::Socket::Done) {
+				receivePacket(packet);
+			}
+			else {
+				log->printf(LOG_LEVEL_INFO, "Noise(): Client encountered error receiving packet " + server->getRemoteAddress().toString());
+				quitThread = true;
+			}
+		}
+	}
 }
 
 void NoiseClient::receivePacket(sf::Packet& packet) {

--- a/src/kernel/NoiseClient.h
+++ b/src/kernel/NoiseClient.h
@@ -15,46 +15,42 @@
 #include "log.h"
 
 class NoiseClient {
-public:
+private:
 	sf::TcpSocket* server;
 	CryptoKernel::Log* log;
 	std::string ipAddress;
 	uint64_t port;
-
+	std::string addr;
 	std::string clientPrivateKey;
-
 	uint8_t clientKey25519[CURVE25519_KEY_LEN];
-
 	std::mutex handshakeMutex;
-
 	NoiseHandshakeState* handshake;
 	Prologue prologue;
 	std::unique_ptr<std::thread> writeInfoThread;
 	bool sentId;
 	bool handshakeComplete;
 	bool handshakeSuccess;
-
-	NoiseCipherState* send_cipher;
-	NoiseCipherState* recv_cipher;
 	std::mutex handshakeCompleteMutex;
-
 	NoiseUtil noiseUtil;
-
-public:
-	NoiseClient(sf::TcpSocket* server, std::string ipAddress, uint64_t port, CryptoKernel::Log* log);
+	std::unique_ptr<std::thread> receiveThread;
 
 	int getProtocolId(Prologue* id, const char* name);
 	int initializeHandshake(NoiseHandshakeState *handshake, const void *prologue, size_t prologue_len);
 	void writeInfo();
 	void setHandshakeComplete(bool complete, bool success);
+    void receiveWrapper();
+	void receivePacket(sf::Packet& packet);
+
+public:
+	NoiseClient(sf::TcpSocket* server, CryptoKernel::Log* log);
+
 	bool getHandshakeComplete();
 	bool getHandshakeSuccess();
 
-    void receiveWrapper();
-	void receivePacket(sf::Packet& packet);
-    std::unique_ptr<std::thread> receiveThread;
+	virtual ~NoiseClient();
 
-    virtual ~NoiseClient();
+	NoiseCipherState* send_cipher;
+	NoiseCipherState* recv_cipher;
 };
 
 #endif /* SRC_KERNEL_NOISECLIENT_H_ */

--- a/src/kernel/NoiseClient.h
+++ b/src/kernel/NoiseClient.h
@@ -16,7 +16,7 @@
 
 class NoiseClient {
 public:
-	std::shared_ptr<sf::TcpSocket> server;
+	sf::TcpSocket* server;
 	CryptoKernel::Log* log;
 	std::string ipAddress;
 	uint64_t port;
@@ -41,7 +41,7 @@ public:
 	NoiseUtil noiseUtil;
 
 public:
-	NoiseClient(std::shared_ptr<sf::TcpSocket> server, std::string ipAddress, uint64_t port, CryptoKernel::Log* log);
+	NoiseClient(sf::TcpSocket* server, std::string ipAddress, uint64_t port, CryptoKernel::Log* log);
 
 	int getProtocolId(Prologue* id, const char* name);
 	int initializeHandshake(NoiseHandshakeState *handshake, const void *prologue, size_t prologue_len);

--- a/src/kernel/NoiseClient.h
+++ b/src/kernel/NoiseClient.h
@@ -48,10 +48,13 @@ public:
 	void writeInfo();
 	void setHandshakeComplete(bool complete, bool success);
 	bool getHandshakeComplete();
-	void receivePacket(sf::Packet packet);
 	bool getHandshakeSuccess();
 
-	virtual ~NoiseClient();
+    void receiveWrapper();
+	void receivePacket(sf::Packet& packet);
+    std::unique_ptr<std::thread> receiveThread;
+
+    virtual ~NoiseClient();
 };
 
 #endif /* SRC_KERNEL_NOISECLIENT_H_ */

--- a/src/kernel/NoiseClient.h
+++ b/src/kernel/NoiseClient.h
@@ -1,0 +1,57 @@
+/*
+ * NoiseClient.h
+ *
+ *  Created on: Aug 2, 2018
+ *      Author: Luke Horgan
+ */
+
+#ifndef SRC_KERNEL_NOISECLIENT_H_
+#define SRC_KERNEL_NOISECLIENT_H_
+
+#include <stdio.h>
+#include <SFML/Network.hpp>
+
+#include "NoiseUtil.h"
+#include "log.h"
+
+class NoiseClient {
+public:
+	std::shared_ptr<sf::TcpSocket> server;
+	CryptoKernel::Log* log;
+	std::string ipAddress;
+	uint64_t port;
+
+	std::string clientPrivateKey;
+
+	uint8_t clientKey25519[CURVE25519_KEY_LEN];
+
+	std::mutex handshakeMutex;
+
+	NoiseHandshakeState* handshake;
+	Prologue prologue;
+	std::unique_ptr<std::thread> writeInfoThread;
+	bool sentId;
+	bool handshakeComplete;
+	bool handshakeSuccess;
+
+	NoiseCipherState* send_cipher;
+	NoiseCipherState* recv_cipher;
+	std::mutex handshakeCompleteMutex;
+
+	NoiseUtil noiseUtil;
+
+public:
+	NoiseClient(std::shared_ptr<sf::TcpSocket> server, std::string ipAddress, uint64_t port, CryptoKernel::Log* log);
+
+	int getProtocolId(Prologue* id, const char* name);
+	int initializeHandshake(NoiseHandshakeState *handshake, const void *prologue, size_t prologue_len);
+	void writeInfo();
+	void setHandshakeComplete(bool complete, bool success);
+	bool getHandshakeComplete();
+	void receivePacket(sf::Packet packet);
+	bool getHandshakeSuccess();
+
+	virtual ~NoiseClient();
+};
+
+#endif /* SRC_KERNEL_NOISECLIENT_H_ */

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -158,8 +158,8 @@ void NoiseServer::receiveWrapper() {
 
     while(!quitThread && !getHandshakeComplete()) {
 		log->printf(LOG_LEVEL_INFO, "server waiting for packet.... " + client->getRemoteAddress().toString());
-		if(selector.wait(sf::seconds(1))) {
-			if(selector.isReady(*client)) {
+		/*if(selector.wait(sf::seconds(1))) {
+			if(selector.isReady(*client)) {*/
 				sf::Packet packet;
 				const auto status = client->receive(packet);
 				if(status == sf::Socket::Done) {
@@ -175,8 +175,8 @@ void NoiseServer::receiveWrapper() {
 					quitThread = true;
 					setHandshakeComplete(true, false);
 				}
-			}
-		}
+			/*}
+		}*/
 	}
 
 	selector.remove(*client);

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -163,6 +163,10 @@ void NoiseServer::receiveWrapper() {
 			if(status == sf::Socket::Done) {
 				receivePacket(packet);
 			}
+			else if(status == sf::Socket::Disconnected) {
+				log->printf(LOG_LEVEL_INFO, "Noise(): Server, " + client->getRemoteAddress().toString() + " disconnected.");
+				quitThread = true;
+			}
 			else {
 				log->printf(LOG_LEVEL_INFO, "Noise(): Server encountered error receiving packet" + client->getRemoteAddress().toString());
 				quitThread = true;

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -303,4 +303,5 @@ NoiseServer::~NoiseServer() {
 		setHandshakeComplete(true, false);
 	}
 	writeInfoThread->join();
+	receiveThread->join();
 }

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -168,10 +168,12 @@ void NoiseServer::receiveWrapper() {
 				else if(status == sf::Socket::Disconnected) {
 					log->printf(LOG_LEVEL_INFO, "Noise(): Server, " + client->getRemoteAddress().toString() + " disconnected.");
 					quitThread = true;
+					setHandshakeComplete(true, false);
 				}
 				else {
 					log->printf(LOG_LEVEL_INFO, "Noise(): Server encountered error receiving packet" + client->getRemoteAddress().toString());
 					quitThread = true;
+					setHandshakeComplete(true, false);
 				}
 			}
 		}

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -63,13 +63,13 @@ NoiseServer::NoiseServer(sf::TcpSocket* client, uint64_t port, CryptoKernel::Log
 	prologue.hash = HASH_SHA256;
 	prologue.dh = DH_25519;
 
-	nid = (NoiseProtocolId*)malloc(sizeof(NoiseProtocolId));
+	//nid = (NoiseProtocolId*)malloc(sizeof(NoiseProtocolId));
 
-	nid->prefix_id = NOISE_PREFIX_STANDARD;
-	nid->pattern_id = NOISE_PATTERN_XX;
-	nid->cipher_id = NOISE_CIPHER_AESGCM;
-	nid->dh_id = NOISE_DH_CURVE25519;
-	nid->hash_id = NOISE_HASH_SHA256;
+	nid.prefix_id = NOISE_PREFIX_STANDARD;
+	nid.pattern_id = NOISE_PATTERN_XX;
+	nid.cipher_id = NOISE_CIPHER_AESGCM;
+	nid.dh_id = NOISE_DH_CURVE25519;
+	nid.hash_id = NOISE_HASH_SHA256;
 
 	writeInfoThread.reset(new std::thread(&NoiseServer::writeInfo, this)); // start the write info thread
     receiveThread.reset(new std::thread(&NoiseServer::receiveWrapper, this));
@@ -186,7 +186,7 @@ void NoiseServer::receivePacket(sf::Packet packet) {
 		if(ok) {
 			std::lock_guard<std::mutex> hc(handshakeMutex);
 			err = noise_handshakestate_new_by_id
-				(&handshake, nid, NOISE_ROLE_RESPONDER);
+				(&handshake, &nid, NOISE_ROLE_RESPONDER);
 			if(err != NOISE_ERROR_NONE) {
 				log->printf(LOG_LEVEL_INFO, "Noise(): Server, create handshake: " + noiseUtil.errToString(err));
 				setHandshakeComplete(true, false);
@@ -197,7 +197,7 @@ void NoiseServer::receivePacket(sf::Packet packet) {
 		/* Set all keys that are needed by the client's requested echo protocol */
 		if(ok) {
 			std::lock_guard<std::mutex> hm(handshakeMutex);
-			if (!initializeHandshake(handshake, nid, &prologue, sizeof(prologue))) {
+			if (!initializeHandshake(handshake, &nid, &prologue, sizeof(prologue))) {
 				log->printf(LOG_LEVEL_WARN, "Noise(): Server, couldn't initialize handshake");
 				setHandshakeComplete(true, false);
 				return;
@@ -309,7 +309,7 @@ NoiseServer::~NoiseServer() {
 	if(!getHandshakeComplete()) {
 		setHandshakeComplete(true, false);
 	}
-	free(nid);
+	//free(nid);
 	client->disconnect();
 	delete client;
 	writeInfoThread->join();

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -1,0 +1,285 @@
+/*
+ * Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "NoiseServer.h"
+
+NoiseServer::NoiseServer(std::shared_ptr<sf::TcpSocket> client, uint64_t port, CryptoKernel::Log* log) {
+	sendCipher = 0;
+	recvCipher = 0;
+
+	this->client = client;
+	this->log = log;
+	this->port = port;
+
+	handshake = 0;
+	messageSize = 0;
+	receivedId = false;
+	receivedPubKey = false;
+
+	handshakeComplete = false;
+	handshakeSuccess = false;
+
+	if(noise_init() != NOISE_ERROR_NONE) {
+		log->printf(LOG_LEVEL_WARN, "Noise(): Server, noise initialization failed.");
+		return;
+	}
+
+	if(!noiseUtil.loadPrivateKey("keys/server_key_25519", serverKey25519, sizeof(serverKey25519))) {
+		log->printf(LOG_LEVEL_INFO, "could not load server key 25519");
+		uint8_t* serverPubKey;
+		uint8_t* serverPrivKey;
+		if(!noiseUtil.writeKeys("keys/server_key_25519.pub", "keys/server_key_25519", &serverPubKey, &serverPrivKey)) {
+			log->printf(LOG_LEVEL_INFO, "Could not write server keys.");
+			setHandshakeComplete(true, false);
+			return;
+		}
+		memcpy(serverKey25519, serverPrivKey, CURVE25519_KEY_LEN); // put the new key in its proper place
+		delete serverPubKey;
+		delete serverPrivKey;
+	}
+
+	prologue.pattern = PATTERN_XX;
+	prologue.psk = PSK_DISABLED;
+	prologue.cipher = CIPHER_AESGCM;
+	prologue.hash = HASH_SHA256;
+	prologue.dh = DH_25519;
+
+	writeInfoThread.reset(new std::thread(&NoiseServer::writeInfo, this)); // start the write info thread
+}
+
+void NoiseServer::writeInfo() {
+	log->printf(LOG_LEVEL_INFO, "SERVER write info starting");
+
+	uint8_t message[MAX_MESSAGE_LEN + 2];
+	unsigned int ok = 1;
+
+	while(!getHandshakeComplete()) { // it might fail in another thread, and so become "complete"
+		handshakeMutex.lock();
+		int action = noise_handshakestate_get_action(handshake);
+		handshakeMutex.unlock();
+		if(action == NOISE_ACTION_WRITE_MESSAGE) {
+			log->printf(LOG_LEVEL_INFO, "Noise(): Server writing message.");
+			/* Write the next handshake message with a zero-length payload */
+			noise_buffer_set_output(mbuf, message + 2, sizeof(message) - 2);
+			handshakeMutex.lock();
+			int err = noise_handshakestate_write_message(handshake, &mbuf, NULL);
+			handshakeMutex.unlock();
+			if (err != NOISE_ERROR_NONE) {
+				log->printf(LOG_LEVEL_WARN, "Noise(): Server, error writing message: " + noiseUtil.errToString(err));
+				setHandshakeComplete(true, false);
+				ok = 0;
+			}
+			message[0] = (uint8_t)(mbuf.size >> 8);
+			message[1] = (uint8_t)mbuf.size;
+
+			sf::Packet packet;
+			packet.append(message, mbuf.size + 2);
+
+			if(client->send(packet) != sf::Socket::Done) {
+				log->printf(LOG_LEVEL_WARN, "Noise(): Server, something went wrong sending packet to client.");
+				setHandshakeComplete(true, false);
+				return;
+			}
+		}
+		else if(action != NOISE_ACTION_READ_MESSAGE && action != NOISE_ACTION_NONE) {
+			break;
+		}
+
+		std::this_thread::sleep_for(std::chrono::milliseconds(50)); // totally arbitrary
+	}
+
+	/* If the action is not "split", then the handshake has failed */
+	handshakeMutex.lock();
+	if(ok && noise_handshakestate_get_action(handshake) != NOISE_ACTION_SPLIT) {
+		log->printf(LOG_LEVEL_INFO, "Noise(): Server, handshake failed.");
+		ok = 0;
+	}
+	handshakeMutex.unlock();
+
+	/* Split out the two CipherState objects for send and receive */
+	int err;
+	if(ok) {
+		handshakeMutex.lock();
+		err = noise_handshakestate_split(handshake, &sendCipher, &recvCipher);
+		if (err != NOISE_ERROR_NONE) {
+			log->printf(LOG_LEVEL_WARN, "Noise(): Server, split failed: " + noiseUtil.errToString(err));
+			ok = 0;
+		}
+		handshakeMutex.unlock();
+	}
+
+	/* We no longer need the HandshakeState */
+	noise_handshakestate_free(handshake);
+	handshake = 0;
+
+	setHandshakeComplete(true, ok);
+}
+
+void NoiseServer::receivePacket(sf::Packet packet) {
+	int err;
+	log->printf(LOG_LEVEL_INFO, "Noise(): Server, receiving a packet.");
+	uint8_t message[MAX_MESSAGE_LEN + 2];
+
+	if(!receivedPubKey) {
+		log->printf(LOG_LEVEL_INFO, "received a packet, hopefully the public key!!");
+		memcpy(clientKey25519, packet.getData(), packet.getDataSize());
+		receivedPubKey = true;
+
+		/* Convert the echo protocol identifier into a Noise protocol identifier */
+		bool ok = true;
+		NoiseProtocolId nid;
+
+		nid.prefix_id = NOISE_PREFIX_STANDARD;
+		nid.pattern_id = NOISE_PATTERN_XX;
+		nid.cipher_id = NOISE_CIPHER_AESGCM;
+		nid.dh_id = NOISE_DH_CURVE25519;
+		nid.hash_id = NOISE_HASH_SHA256;
+
+		/* Create a HandshakeState object to manage the server's handshake */
+		if(ok) {
+			std::lock_guard<std::mutex> hc(handshakeMutex);
+			err = noise_handshakestate_new_by_id
+				(&handshake, &nid, NOISE_ROLE_RESPONDER);
+			if(err != NOISE_ERROR_NONE) {
+				log->printf(LOG_LEVEL_INFO, "Noise(): Server, create handshake: " + noiseUtil.errToString(err));
+				setHandshakeComplete(true, false);
+				return;
+			}
+		}
+
+		/* Set all keys that are needed by the client's requested echo protocol */
+		if(ok) {
+			std::lock_guard<std::mutex> hm(handshakeMutex);
+			if (!initializeHandshake(handshake, &nid, &prologue, sizeof(prologue))) {
+				log->printf(LOG_LEVEL_WARN, "Noise(): Server, couldn't initialize handshake");
+				setHandshakeComplete(true, false);
+				return;
+			}
+		}
+
+		/* Start the handshake */
+		if(ok) {
+			std::lock_guard<std::mutex> hc(handshakeMutex);
+			err = noise_handshakestate_start(handshake);
+			if (err != NOISE_ERROR_NONE) {
+				log->printf(LOG_LEVEL_INFO, "Noise(): Server, couldn't start handshake: " + noiseUtil.errToString(err));
+				setHandshakeComplete(true, false);
+				return;
+			}
+		}
+	}
+	else {
+		std::lock_guard<std::mutex> hm(handshakeMutex);
+		int action = noise_handshakestate_get_action(handshake);
+		if(action == NOISE_ACTION_READ_MESSAGE) {
+			log->printf(LOG_LEVEL_INFO, "Noise(): Server, reading message.");
+			messageSize = packet.getDataSize();
+			memcpy(message, packet.getData(), packet.getDataSize());
+
+			noise_buffer_set_input(mbuf, message + 2, messageSize - 2);
+			err = noise_handshakestate_read_message(handshake, &mbuf, NULL);
+			if (err != NOISE_ERROR_NONE) {
+				log->printf(LOG_LEVEL_WARN, "Noise(): Server, read handshake error: " + noiseUtil.errToString(err));
+				setHandshakeComplete(true, false);
+				return;
+			}
+		}
+	}
+}
+
+/* Initialize's the handshake with all necessary keys */
+int NoiseServer::initializeHandshake(NoiseHandshakeState* handshake, const NoiseProtocolId* nid, const void* prologue, size_t prologueLen) {
+	NoiseDHState *dh;
+	int dhId;
+	int err;
+
+	/* Set the prologue first */
+	err = noise_handshakestate_set_prologue(handshake, prologue, prologueLen);
+	if(err != NOISE_ERROR_NONE) {
+		log->printf(LOG_LEVEL_WARN, "Noise(): Server, prologue error: " + noiseUtil.errToString(err));
+		return 0;
+	}
+
+	/* Set the local keypair for the server based on the DH algorithm */
+	if(noise_handshakestate_needs_local_keypair(handshake)) {
+		dh = noise_handshakestate_get_local_keypair_dh(handshake);
+		dhId = noise_dhstate_get_dh_id(dh);
+		if(dhId == NOISE_DH_CURVE25519) {
+			err = noise_dhstate_set_keypair_private(dh, serverKey25519, sizeof(serverKey25519));
+		}
+		else {
+			err = NOISE_ERROR_UNKNOWN_ID;
+		}
+		if(err != NOISE_ERROR_NONE) {
+			log->printf(LOG_LEVEL_WARN, "Noise(): Server, set private key error, " + noiseUtil.errToString(err));
+			return 0;
+		}
+	}
+
+	/* Set the remote public key for the client */
+	if(noise_handshakestate_needs_remote_public_key(handshake)) {
+		dh = noise_handshakestate_get_remote_public_key_dh(handshake);
+		dhId = noise_dhstate_get_dh_id(dh);
+		if(dhId == NOISE_DH_CURVE25519) {
+			err = noise_dhstate_set_public_key
+				(dh, clientKey25519, sizeof(clientKey25519));
+		}
+		else {
+			err = NOISE_ERROR_UNKNOWN_ID;
+		}
+		if(err != NOISE_ERROR_NONE) {
+			log->printf(LOG_LEVEL_WARN, "Noise(): Server, set public key error, " + noiseUtil.errToString(err));
+			return 0;
+		}
+	}
+
+	/* Ready to go */
+	return 1;
+}
+
+void NoiseServer::setHandshakeComplete(bool complete, bool success) {
+	if(success) {
+		log->printf(LOG_LEVEL_INFO, "Noise(): Server handshake succeeded");
+	}
+
+	std::lock_guard<std::mutex> hcm(handshakeCompleteMutex);
+	handshakeComplete = complete;
+	handshakeSuccess = success;
+}
+
+bool NoiseServer::getHandshakeSuccess() {
+	std::lock_guard<std::mutex> hcm(handshakeCompleteMutex);
+	return handshakeSuccess;
+}
+
+bool NoiseServer::getHandshakeComplete() {
+	std::lock_guard<std::mutex> hcm(handshakeCompleteMutex);
+	return handshakeComplete;
+}
+
+NoiseServer::~NoiseServer() {
+	log->printf(LOG_LEVEL_INFO, "Cleaning up noise server");
+	if(!getHandshakeComplete()) {
+		setHandshakeComplete(true, false);
+	}
+	writeInfoThread->join();
+}

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -199,7 +199,7 @@ void NoiseServer::receivePacket(sf::Packet packet) {
 		/* Set all keys that are needed by the client's requested echo protocol */
 		if(ok) {
 			std::lock_guard<std::mutex> hm(handshakeMutex);
-			if (!initializeHandshake(handshake, &nid, &prologue, sizeof(prologue))) {
+			if (!initializeHandshake(handshake, sizeof(prologue))) {
 				log->printf(LOG_LEVEL_WARN, "Noise(): Server, couldn't initialize handshake");
 				setHandshakeComplete(true, false);
 				return;
@@ -237,13 +237,13 @@ void NoiseServer::receivePacket(sf::Packet packet) {
 }
 
 /* Initialize's the handshake with all necessary keys */
-int NoiseServer::initializeHandshake(NoiseHandshakeState* handshake, const NoiseProtocolId* nid, const void* prologue, size_t prologueLen) {
+int NoiseServer::initializeHandshake(NoiseHandshakeState* handshake, size_t prologueLen) {
 	NoiseDHState *dh;
 	int dhId;
 	int err;
 
 	/* Set the prologue first */
-	err = noise_handshakestate_set_prologue(handshake, prologue, prologueLen);
+	err = noise_handshakestate_set_prologue(handshake, &prologue, prologueLen);
 	if(err != NOISE_ERROR_NONE) {
 		log->printf(LOG_LEVEL_WARN, "Noise(): Server, prologue error: " + noiseUtil.errToString(err));
 		return 0;

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -157,19 +157,21 @@ void NoiseServer::receiveWrapper() {
 
     while(!quitThread && !getHandshakeComplete()) {
 		log->printf(LOG_LEVEL_INFO, "server waiting for packet.... " + client->getRemoteAddress().toString());
-		if(selector.isReady(*client)) {
-			sf::Packet packet;
-			const auto status = client->receive(packet);
-			if(status == sf::Socket::Done) {
-				receivePacket(packet);
-			}
-			else if(status == sf::Socket::Disconnected) {
-				log->printf(LOG_LEVEL_INFO, "Noise(): Server, " + client->getRemoteAddress().toString() + " disconnected.");
-				quitThread = true;
-			}
-			else {
-				log->printf(LOG_LEVEL_INFO, "Noise(): Server encountered error receiving packet" + client->getRemoteAddress().toString());
-				quitThread = true;
+		if(selector.wait(sf::seconds(2))) {
+			if(selector.isReady(*client)) {
+				sf::Packet packet;
+				const auto status = client->receive(packet);
+				if(status == sf::Socket::Done) {
+					receivePacket(packet);
+				}
+				else if(status == sf::Socket::Disconnected) {
+					log->printf(LOG_LEVEL_INFO, "Noise(): Server, " + client->getRemoteAddress().toString() + " disconnected.");
+					quitThread = true;
+				}
+				else {
+					log->printf(LOG_LEVEL_INFO, "Noise(): Server encountered error receiving packet" + client->getRemoteAddress().toString());
+					quitThread = true;
+				}
 			}
 		}
 	}

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -157,7 +157,7 @@ void NoiseServer::receiveWrapper() {
 
     while(!quitThread && !getHandshakeComplete()) {
 		log->printf(LOG_LEVEL_INFO, "server waiting for packet.... " + client->getRemoteAddress().toString());
-		if(selector.wait(sf::seconds(2))) {
+		if(selector.isReady(*client)) {
 			sf::Packet packet;
 			const auto status = client->receive(packet);
 			if(status == sf::Socket::Done) {

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -155,18 +155,20 @@ void NoiseServer::receiveWrapper() {
     selector.add(*client);
     bool quitThread = false;
 
-    while(!quitThread && !getHandshakeComplete())
-    if(selector.wait(sf::seconds(2))) {
-        sf::Packet packet;
-        const auto status = client->receive(packet);
-        if(status == sf::Socket::Done) {
-            receivePacket(packet);
-        }
-        else {
-            log->printf(LOG_LEVEL_INFO, "Noise(): Server encountered error receiving packet");
-            quitThread = true;
-        }
-    }
+    while(!quitThread && !getHandshakeComplete()) {
+		log->printf(LOG_LEVEL_INFO, "server waiting for packet....");
+		if(selector.wait(sf::seconds(2))) {
+			sf::Packet packet;
+			const auto status = client->receive(packet);
+			if(status == sf::Socket::Done) {
+				receivePacket(packet);
+			}
+			else {
+				log->printf(LOG_LEVEL_INFO, "Noise(): Server encountered error receiving packet");
+				quitThread = true;
+			}
+		}
+	}
 
 	selector.remove(*client);
 }

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -158,8 +158,8 @@ void NoiseServer::receiveWrapper() {
 
     while(!quitThread && !getHandshakeComplete()) {
 		log->printf(LOG_LEVEL_INFO, "server waiting for packet.... " + client->getRemoteAddress().toString());
-		/*if(selector.wait(sf::seconds(1))) {
-			if(selector.isReady(*client)) {*/
+		if(selector.wait(sf::seconds(1))) {
+			//if(selector.isReady(*client)) {
 				sf::Packet packet;
 				const auto status = client->receive(packet);
 				if(status == sf::Socket::Done) {
@@ -175,8 +175,8 @@ void NoiseServer::receiveWrapper() {
 					quitThread = true;
 					setHandshakeComplete(true, false);
 				}
-			/*}
-		}*/
+			//}
+		}
 	}
 
 	selector.remove(*client);

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -304,4 +304,5 @@ NoiseServer::~NoiseServer() {
 	}
 	writeInfoThread->join();
 	receiveThread->join();
+	log->printf(LOG_LEVEL_INFO, "Cleaned up noise server");
 }

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -153,10 +153,10 @@ void NoiseServer::receiveWrapper() {
     log->printf(LOG_LEVEL_INFO, "Noise(): Server, receive wrapper starting. " + client->getRemoteAddress().toString());
     bool quitThread = false;
 
-    while(!quitThread && !getHandshakeComplete()) {
-		sf::SocketSelector selector;
-    	selector.add(*client);
+	sf::SocketSelector selector;
+	selector.add(*client);
 
+    while(!quitThread && !getHandshakeComplete()) {
 		log->printf(LOG_LEVEL_INFO, "server waiting for packet.... " + client->getRemoteAddress().toString());
 		if(selector.wait(sf::seconds(1))) {
 			if(selector.isReady(*client)) {
@@ -176,6 +176,8 @@ void NoiseServer::receiveWrapper() {
 			}
 		}
 	}
+
+	selector.remove(*client);
 }
 
 void NoiseServer::receivePacket(sf::Packet packet) {

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -74,7 +74,7 @@ void NoiseServer::writeInfo() {
 	unsigned int ok = 1;
 
 	while(!getHandshakeComplete()) { // it might fail in another thread, and so become "complete"
-		while(!receivedPubKey) {
+		if(!receivedPubKey) {
 			continue;
 		}
 		

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -141,7 +141,7 @@ void NoiseServer::receiveWrapper() {
     selector.add(*client.get());
     bool quitThread = false;
 
-    while(!quitThread)
+    while(!quitThread && !getHandshakeComplete())
     if(selector.wait(sf::seconds(2))) {
         sf::Packet packet;
         const auto status = client->receive(packet);

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -302,6 +302,7 @@ NoiseServer::~NoiseServer() {
 	if(!getHandshakeComplete()) {
 		setHandshakeComplete(true, false);
 	}
+	client->disconnect();
 	writeInfoThread->join();
 	receiveThread->join();
 	log->printf(LOG_LEVEL_INFO, "Cleaned up noise server");

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -65,11 +65,13 @@ NoiseServer::NoiseServer(sf::TcpSocket* client, uint64_t port, CryptoKernel::Log
 
 	//nid = (NoiseProtocolId*)malloc(sizeof(NoiseProtocolId));
 
+	memset(&nid, 0, sizeof(NoiseProtocolId));
 	nid.prefix_id = NOISE_PREFIX_STANDARD;
 	nid.pattern_id = NOISE_PATTERN_XX;
 	nid.cipher_id = NOISE_CIPHER_AESGCM;
 	nid.dh_id = NOISE_DH_CURVE25519;
 	nid.hash_id = NOISE_HASH_SHA256;
+	nid.hybrid_id = NOISE_DH_NONE;
 
 	writeInfoThread.reset(new std::thread(&NoiseServer::writeInfo, this)); // start the write info thread
     receiveThread.reset(new std::thread(&NoiseServer::receiveWrapper, this));

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -151,13 +151,14 @@ void NoiseServer::writeInfo() {
 
 void NoiseServer::receiveWrapper() {
     log->printf(LOG_LEVEL_INFO, "Noise(): Server, receive wrapper starting. " + client->getRemoteAddress().toString());
-    sf::SocketSelector selector;
-    selector.add(*client);
     bool quitThread = false;
 
     while(!quitThread && !getHandshakeComplete()) {
+		sf::SocketSelector selector;
+    	selector.add(*client);
+
 		log->printf(LOG_LEVEL_INFO, "server waiting for packet.... " + client->getRemoteAddress().toString());
-		if(selector.wait(sf::seconds(2))) {
+		if(selector.wait(sf::seconds(1))) {
 			if(selector.isReady(*client)) {
 				sf::Packet packet;
 				const auto status = client->receive(packet);
@@ -175,8 +176,6 @@ void NoiseServer::receiveWrapper() {
 			}
 		}
 	}
-
-	selector.remove(*client);
 }
 
 void NoiseServer::receivePacket(sf::Packet packet) {

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -74,6 +74,10 @@ void NoiseServer::writeInfo() {
 	unsigned int ok = 1;
 
 	while(!getHandshakeComplete()) { // it might fail in another thread, and so become "complete"
+		while(!receivedPubKey) {
+			continue;
+		}
+		
 		handshakeMutex.lock();
 		int action = noise_handshakestate_get_action(handshake);
 		handshakeMutex.unlock();

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -22,7 +22,7 @@
 
 #include "NoiseServer.h"
 
-NoiseServer::NoiseServer(std::shared_ptr<sf::TcpSocket> client, uint64_t port, CryptoKernel::Log* log) {
+NoiseServer::NoiseServer(sf::TcpSocket* client, uint64_t port, CryptoKernel::Log* log) {
 	sendCipher = 0;
 	recvCipher = 0;
 
@@ -142,7 +142,7 @@ void NoiseServer::writeInfo() {
 void NoiseServer::receiveWrapper() {
     log->printf(LOG_LEVEL_INFO, "Noise(): Server, receive wrapper starting.");
     sf::SocketSelector selector;
-    selector.add(*client.get());
+    selector.add(*client);
     bool quitThread = false;
 
     while(!quitThread && !getHandshakeComplete())
@@ -157,6 +157,8 @@ void NoiseServer::receiveWrapper() {
             quitThread = true;
         }
     }
+
+	selector.remove(*client);
 }
 
 void NoiseServer::receivePacket(sf::Packet packet) {
@@ -307,6 +309,7 @@ NoiseServer::~NoiseServer() {
 		setHandshakeComplete(true, false);
 	}
 	client->disconnect();
+	delete client;
 	writeInfoThread->join();
 	receiveThread->join();
 	log->printf(LOG_LEVEL_INFO, "Cleaned up noise server");

--- a/src/kernel/NoiseServer.cpp
+++ b/src/kernel/NoiseServer.cpp
@@ -63,6 +63,14 @@ NoiseServer::NoiseServer(sf::TcpSocket* client, uint64_t port, CryptoKernel::Log
 	prologue.hash = HASH_SHA256;
 	prologue.dh = DH_25519;
 
+	nid = (NoiseProtocolId*)malloc(sizeof(NoiseProtocolId));
+
+	nid->prefix_id = NOISE_PREFIX_STANDARD;
+	nid->pattern_id = NOISE_PATTERN_XX;
+	nid->cipher_id = NOISE_CIPHER_AESGCM;
+	nid->dh_id = NOISE_DH_CURVE25519;
+	nid->hash_id = NOISE_HASH_SHA256;
+
 	writeInfoThread.reset(new std::thread(&NoiseServer::writeInfo, this)); // start the write info thread
     receiveThread.reset(new std::thread(&NoiseServer::receiveWrapper, this));
 }
@@ -167,25 +175,18 @@ void NoiseServer::receivePacket(sf::Packet packet) {
 	uint8_t message[MAX_MESSAGE_LEN + 2];
 
 	if(!receivedPubKey) {
+		receivedPubKey = true;
 		log->printf(LOG_LEVEL_INFO, "received a packet, hopefully the public key!!");
 		memcpy(clientKey25519, packet.getData(), packet.getDataSize());
-		receivedPubKey = true;
 
 		/* Convert the echo protocol identifier into a Noise protocol identifier */
 		bool ok = true;
-		NoiseProtocolId nid;
-
-		nid.prefix_id = NOISE_PREFIX_STANDARD;
-		nid.pattern_id = NOISE_PATTERN_XX;
-		nid.cipher_id = NOISE_CIPHER_AESGCM;
-		nid.dh_id = NOISE_DH_CURVE25519;
-		nid.hash_id = NOISE_HASH_SHA256;
 
 		/* Create a HandshakeState object to manage the server's handshake */
 		if(ok) {
 			std::lock_guard<std::mutex> hc(handshakeMutex);
 			err = noise_handshakestate_new_by_id
-				(&handshake, &nid, NOISE_ROLE_RESPONDER);
+				(&handshake, nid, NOISE_ROLE_RESPONDER);
 			if(err != NOISE_ERROR_NONE) {
 				log->printf(LOG_LEVEL_INFO, "Noise(): Server, create handshake: " + noiseUtil.errToString(err));
 				setHandshakeComplete(true, false);
@@ -196,7 +197,7 @@ void NoiseServer::receivePacket(sf::Packet packet) {
 		/* Set all keys that are needed by the client's requested echo protocol */
 		if(ok) {
 			std::lock_guard<std::mutex> hm(handshakeMutex);
-			if (!initializeHandshake(handshake, &nid, &prologue, sizeof(prologue))) {
+			if (!initializeHandshake(handshake, nid, &prologue, sizeof(prologue))) {
 				log->printf(LOG_LEVEL_WARN, "Noise(): Server, couldn't initialize handshake");
 				setHandshakeComplete(true, false);
 				return;
@@ -308,6 +309,7 @@ NoiseServer::~NoiseServer() {
 	if(!getHandshakeComplete()) {
 		setHandshakeComplete(true, false);
 	}
+	free(nid);
 	client->disconnect();
 	delete client;
 	writeInfoThread->join();

--- a/src/kernel/NoiseServer.h
+++ b/src/kernel/NoiseServer.h
@@ -52,7 +52,7 @@ public:
 	void setHandshakeComplete(bool complete, bool success);
 	bool getHandshakeComplete();
 	bool getHandshakeSuccess();
-	int initializeHandshake(NoiseHandshakeState* handshake, const NoiseProtocolId* nid, const void* prologue, size_t prologue_len);
+	int initializeHandshake(NoiseHandshakeState* handshake, size_t prologue_len);
 
 	void receiveWrapper();
 	void receivePacket(sf::Packet packet);

--- a/src/kernel/NoiseServer.h
+++ b/src/kernel/NoiseServer.h
@@ -43,6 +43,8 @@ public:
 	bool handshakeSuccess;
 	std::mutex handshakeCompleteMutex;
 
+	NoiseProtocolId* nid;
+
 public:
 	NoiseServer(sf::TcpSocket* client, uint64_t port, CryptoKernel::Log* log);
 

--- a/src/kernel/NoiseServer.h
+++ b/src/kernel/NoiseServer.h
@@ -1,0 +1,59 @@
+/*
+ * NoiseServer.h
+ *
+ *  Created on: Aug 2, 2018
+ *      Author: luke
+ */
+
+#ifndef SRC_KERNEL_NOISESERVER_H_
+#define SRC_KERNEL_NOISESERVER_H_
+
+#include <stdio.h>
+#include <SFML/Network.hpp>
+
+#include "NoiseUtil.h"
+#include "log.h"
+
+class NoiseServer {
+public:
+	uint8_t clientKey25519[CURVE25519_KEY_LEN];
+	uint8_t serverKey25519[CURVE25519_KEY_LEN];
+
+	std::shared_ptr<sf::TcpSocket> client;
+	CryptoKernel::Log* log;
+	uint64_t port;
+
+	bool receivedId;
+	bool receivedPubKey;
+	size_t messageSize;
+	NoiseBuffer mbuf;
+	NoiseHandshakeState *handshake;
+	Prologue prologue;
+
+	std::mutex handshakeMutex;
+
+	std::unique_ptr<std::thread> writeInfoThread;
+
+	NoiseCipherState* sendCipher;
+	NoiseCipherState* recvCipher;
+
+	NoiseUtil noiseUtil;
+
+	bool handshakeComplete;
+	bool handshakeSuccess;
+	std::mutex handshakeCompleteMutex;
+
+public:
+	NoiseServer(std::shared_ptr<sf::TcpSocket> client, uint64_t port, CryptoKernel::Log* log);
+
+	void writeInfo();
+	void receivePacket(sf::Packet packet);
+	void setHandshakeComplete(bool complete, bool success);
+	bool getHandshakeComplete();
+	bool getHandshakeSuccess();
+	int initializeHandshake(NoiseHandshakeState* handshake, const NoiseProtocolId* nid, const void* prologue, size_t prologue_len);
+
+	virtual ~NoiseServer();
+};
+
+#endif /* SRC_KERNEL_NOISESERVER_H_ */

--- a/src/kernel/NoiseServer.h
+++ b/src/kernel/NoiseServer.h
@@ -18,45 +18,37 @@ class NoiseServer {
 public:
 	uint8_t clientKey25519[CURVE25519_KEY_LEN];
 	uint8_t serverKey25519[CURVE25519_KEY_LEN];
-
 	sf::TcpSocket* client;
 	CryptoKernel::Log* log;
 	uint64_t port;
-
 	bool receivedId;
 	bool receivedPubKey;
 	size_t messageSize;
 	NoiseBuffer mbuf;
 	NoiseHandshakeState *handshake;
 	Prologue prologue;
-
 	std::mutex handshakeMutex;
-
 	std::unique_ptr<std::thread> writeInfoThread;
-
 	NoiseCipherState* sendCipher;
 	NoiseCipherState* recvCipher;
-
 	NoiseUtil noiseUtil;
-
 	bool handshakeComplete;
 	bool handshakeSuccess;
 	std::mutex handshakeCompleteMutex;
-
 	NoiseProtocolId nid;
-
-public:
-	NoiseServer(sf::TcpSocket* client, uint64_t port, CryptoKernel::Log* log);
+	std::string addr;
+	std::unique_ptr<std::thread> receiveThread;
 
 	void writeInfo();
 	void setHandshakeComplete(bool complete, bool success);
-	bool getHandshakeComplete();
-	bool getHandshakeSuccess();
 	int initializeHandshake(NoiseHandshakeState* handshake, size_t prologue_len);
-
 	void receiveWrapper();
 	void receivePacket(sf::Packet packet);
-	std::unique_ptr<std::thread> receiveThread;
+	
+	NoiseServer(sf::TcpSocket* client, CryptoKernel::Log* log);
+
+	bool getHandshakeComplete();
+	bool getHandshakeSuccess();
 
 	virtual ~NoiseServer();
 };

--- a/src/kernel/NoiseServer.h
+++ b/src/kernel/NoiseServer.h
@@ -19,7 +19,7 @@ public:
 	uint8_t clientKey25519[CURVE25519_KEY_LEN];
 	uint8_t serverKey25519[CURVE25519_KEY_LEN];
 
-	std::shared_ptr<sf::TcpSocket> client;
+	sf::TcpSocket* client;
 	CryptoKernel::Log* log;
 	uint64_t port;
 
@@ -44,7 +44,7 @@ public:
 	std::mutex handshakeCompleteMutex;
 
 public:
-	NoiseServer(std::shared_ptr<sf::TcpSocket> client, uint64_t port, CryptoKernel::Log* log);
+	NoiseServer(sf::TcpSocket* client, uint64_t port, CryptoKernel::Log* log);
 
 	void writeInfo();
 	void setHandshakeComplete(bool complete, bool success);

--- a/src/kernel/NoiseServer.h
+++ b/src/kernel/NoiseServer.h
@@ -47,11 +47,14 @@ public:
 	NoiseServer(std::shared_ptr<sf::TcpSocket> client, uint64_t port, CryptoKernel::Log* log);
 
 	void writeInfo();
-	void receivePacket(sf::Packet packet);
 	void setHandshakeComplete(bool complete, bool success);
 	bool getHandshakeComplete();
 	bool getHandshakeSuccess();
 	int initializeHandshake(NoiseHandshakeState* handshake, const NoiseProtocolId* nid, const void* prologue, size_t prologue_len);
+
+	void receiveWrapper();
+	void receivePacket(sf::Packet packet);
+	std::unique_ptr<std::thread> receiveThread;
 
 	virtual ~NoiseServer();
 };

--- a/src/kernel/NoiseServer.h
+++ b/src/kernel/NoiseServer.h
@@ -43,7 +43,7 @@ public:
 	bool handshakeSuccess;
 	std::mutex handshakeCompleteMutex;
 
-	NoiseProtocolId* nid;
+	NoiseProtocolId nid;
 
 public:
 	NoiseServer(sf::TcpSocket* client, uint64_t port, CryptoKernel::Log* log);

--- a/src/kernel/NoiseUtil.cpp
+++ b/src/kernel/NoiseUtil.cpp
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "NoiseUtil.h"
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <string>
+
+NoiseUtil::NoiseUtil() {
+}
+
+/* Loads a binary private key from a file.  Returns non-zero if OK. */
+int NoiseUtil::loadPrivateKey(const char* filename, uint8_t* key, size_t len) {
+	FILE *file = fopen(filename, "rb");
+	size_t posn = 0;
+	int ch;
+	if (len > MAX_DH_KEY_LEN) {
+		fprintf(stderr, "private key length is not supported\n");
+		return 0;
+	}
+	if (!file) {
+		perror(filename);
+		return 0;
+	}
+	while ((ch = getc(file)) != EOF) {
+		if (posn >= len) {
+			fclose(file);
+			fprintf(stderr, "%s: private key value is too long\n", filename);
+			return 0;
+		}
+		key[posn++] = (uint8_t)ch;
+	}
+	if (posn < len) {
+		fclose(file);
+		fprintf(stderr, "%s: private key value is too short\n", filename);
+		return 0;
+	}
+	fclose(file);
+	return 1;
+}
+
+/* Loads a base64-encoded public key from a file.  Returns non-zero if OK. */
+int NoiseUtil::loadPublicKey(const char *filename, uint8_t *key, size_t len) {
+	FILE *file = fopen(filename, "rb");
+	uint32_t group = 0;
+	size_t group_size = 0;
+	uint32_t digit = 0;
+	size_t posn = 0;
+	int ch;
+	if (len > MAX_DH_KEY_LEN) {
+		fprintf(stderr, "public key length is not supported\n");
+		return 0;
+	}
+	if (!file) {
+		perror(filename);
+		return 0;
+	}
+	while ((ch = getc(file)) != EOF) {
+		if (ch >= 'A' && ch <= 'Z') {
+			digit = ch - 'A';
+		} else if (ch >= 'a' && ch <= 'z') {
+			digit = ch - 'a' + 26;
+		} else if (ch >= '0' && ch <= '9') {
+			digit = ch - '0' + 52;
+		} else if (ch == '+') {
+			digit = 62;
+		} else if (ch == '/') {
+			digit = 63;
+		} else if (ch == '=') {
+			break;
+		} else if (ch != ' ' && ch != '\t' && ch != '\r' && ch != '\n') {
+			fclose(file);
+			fprintf(stderr, "%s: invalid character in public key file\n", filename);
+			return 0;
+		}
+		group = (group << 6) | digit;
+		if (++group_size >= 4) {
+			if ((len - posn) < 3) {
+				fclose(file);
+				fprintf(stderr, "%s: public key value is too long\n", filename);
+				return 0;
+			}
+			group_size = 0;
+			key[posn++] = (uint8_t)(group >> 16);
+			key[posn++] = (uint8_t)(group >> 8);
+			key[posn++] = (uint8_t)group;
+		}
+	}
+	if (group_size == 3) {
+		if ((len - posn) < 2) {
+			fclose(file);
+			fprintf(stderr, "%s: public key value is too long\n", filename);
+			return 0;
+		}
+		key[posn++] = (uint8_t)(group >> 10);
+		key[posn++] = (uint8_t)(group >> 2);
+	} else if (group_size == 2) {
+		if ((len - posn) < 1) {
+			fclose(file);
+			fprintf(stderr, "%s: public key value is too long\n", filename);
+			return 0;
+		}
+		key[posn++] = (uint8_t)(group >> 4);
+	}
+	if (posn < len) {
+		fclose(file);
+		fprintf(stderr, "%s: public key value is too short\n", filename);
+		return 0;
+	}
+	fclose(file);
+	return 1;
+}
+
+/* Saves a binary private key to a file.  Returns non-zero if OK. */
+int NoiseUtil::savePrivateKey(const char *filename, const uint8_t *key, size_t len) {
+    FILE *file = fopen(filename, "wb");
+    size_t posn;
+    if (!file) {
+        perror(filename);
+        return 0;
+    }
+    for (posn = 0; posn < len; ++posn)
+        putc(key[posn], file);
+    fclose(file);
+    return 1;
+}
+
+/* Saves a base64-encoded public key to a file.  Returns non-zero if OK. */
+int NoiseUtil::savePublicKey(const char *filename, const uint8_t *key, size_t len) {
+    static char const base64_chars[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    FILE *file = fopen(filename, "wb");
+    size_t posn = 0;
+    uint32_t group;
+    if (!file) {
+        perror(filename);
+        return 0;
+    }
+    while ((len - posn) >= 3) {
+        group = (((uint32_t)(key[posn])) << 16) |
+                (((uint32_t)(key[posn + 1])) << 8) |
+                 ((uint32_t)(key[posn + 2]));
+        putc(base64_chars[(group >> 18) & 0x3F], file);
+        putc(base64_chars[(group >> 12) & 0x3F], file);
+        putc(base64_chars[(group >> 6) & 0x3F], file);
+        putc(base64_chars[group & 0x3F], file);
+        posn += 3;
+    }
+    if ((len - posn) == 2) {
+        group = (((uint32_t)(key[posn])) << 16) |
+                (((uint32_t)(key[posn + 1])) << 8);
+        putc(base64_chars[(group >> 18) & 0x3F], file);
+        putc(base64_chars[(group >> 12) & 0x3F], file);
+        putc(base64_chars[(group >> 6) & 0x3F], file);
+        putc('=', file);
+    } else if ((len - posn) == 1) {
+        group = ((uint32_t)(key[posn])) << 16;
+        putc(base64_chars[(group >> 18) & 0x3F], file);
+        putc(base64_chars[(group >> 12) & 0x3F], file);
+        putc('=', file);
+        putc('=', file);
+    }
+    fclose(file);
+    return 1;
+}
+
+// generate keys and write them to disk
+int NoiseUtil::writeKeys(const char* pubKeyName, const char* privKeyName, uint8_t** pub_key, uint8_t** priv_key) {
+	NoiseDHState* dh;
+	int err = noise_dhstate_new_by_name(&dh, "25519");
+	if(err != NOISE_ERROR_NONE) {
+		return 0;
+	}
+	err = noise_dhstate_generate_keypair(dh);
+	if(err != NOISE_ERROR_NONE) {
+		noise_dhstate_free(dh);
+		return 0;
+	}
+
+	/* Fetch the keypair to be saved */
+	size_t priv_key_len = noise_dhstate_get_private_key_length(dh);
+	size_t pub_key_len = noise_dhstate_get_public_key_length(dh);
+
+	*priv_key = (uint8_t *)malloc(priv_key_len);
+	*pub_key = (uint8_t *)malloc(pub_key_len);
+
+	if (!priv_key || !pub_key) {
+		fprintf(stderr, "Out of memory\n");
+		return 0;
+	}
+	err = noise_dhstate_get_keypair
+		(dh, *priv_key, priv_key_len, *pub_key, pub_key_len);
+	if (err != NOISE_ERROR_NONE) {
+		noise_perror("get keypair for saving", err);
+		return 0;
+	}
+
+	int ok = 1;
+
+	/* Save the keys */
+	ok = savePrivateKey(privKeyName, *priv_key, priv_key_len);
+	if (ok)
+		ok = savePublicKey(pubKeyName, *pub_key, pub_key_len);
+
+	/* Clean up */
+	noise_dhstate_free(dh);
+
+	if (!ok) {
+		unlink(privKeyName);
+		unlink(pubKeyName);
+	}
+
+	return ok;
+}
+
+std::string NoiseUtil::errToString(int err) {
+	char* buf = new char[4096];
+	noise_strerror(err, buf, 4096);
+	std::string errString(buf);
+	delete buf;
+	return errString;
+}
+
+NoiseUtil::~NoiseUtil() {
+}

--- a/src/kernel/NoiseUtil.h
+++ b/src/kernel/NoiseUtil.h
@@ -1,0 +1,51 @@
+/*
+ * NoiseUtil.h
+ *
+ *  Created on: Aug 2, 2018
+ *      Author: Luke Horgan
+ */
+
+#ifndef SRC_KERNEL_NOISEUTIL_H_
+#define SRC_KERNEL_NOISEUTIL_H_
+
+#include <noise/protocol.h>
+#include <stdio.h>
+#include <string.h>
+#include <thread>
+
+#define MAX_DH_KEY_LEN 2048
+#define CURVE25519_KEY_LEN 32
+#define MAX_DH_KEY_LEN 2048
+#define MAX_MESSAGE_LEN 4096
+
+#define PATTERN_XX             0x0A
+#define CIPHER_AESGCM          0x01
+#define DH_25519               0x00
+#define HASH_SHA256            0x00
+#define PSK_DISABLED           0x00
+
+struct Prologue {
+    uint8_t psk;
+    uint8_t pattern;
+    uint8_t cipher;
+    uint8_t dh;
+    uint8_t hash;
+
+};
+
+class NoiseUtil {
+public:
+	NoiseUtil();
+
+	int loadPrivateKey(const char* filename, uint8_t* key, size_t len);
+	int loadPublicKey(const char* filename, uint8_t* key, size_t len);
+	int toNoiseProtocolId(NoiseProtocolId* nid, const Prologue* id);
+	int savePrivateKey(const char* filename, const uint8_t* key, size_t len);
+	int savePublicKey(const char* filename, const uint8_t* key, size_t len);
+	int writeKeys(const char* pubKeyName, const char* privKeyName, uint8_t** pub_key, uint8_t** priv_key);
+	std::string errToString(int err);
+
+	virtual ~NoiseUtil();
+};
+
+#endif /* SRC_KERNEL_NOISEUTIL_H_ */

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -338,7 +338,7 @@ void CryptoKernel::Network::postHandshakeConnect() {
 void CryptoKernel::Network::transferConnection(std::string addr, NoiseCipherState* send_cipher, NoiseCipherState* recv_cipher) {
 	log->printf(LOG_LEVEL_INFO, "Transferring connection for " + addr);
 	auto it = connectedPending.find(addr);
-	if(it != connectedPending.end()) {
+	if(it != connectedPending.end() && it->second->acquire()) {
 		log->printf(LOG_LEVEL_INFO, "CONNECTION VERSION 1: " + it->second->getPeerStats().version);
 		Connection* connection = std::move(it->second.get());
 		log->printf(LOG_LEVEL_INFO, "CONNECTION VERSION 2: " + connection->getPeerStats().version);
@@ -346,6 +346,8 @@ void CryptoKernel::Network::transferConnection(std::string addr, NoiseCipherStat
 		connectedPending.erase(addr);
 
 		log->printf(LOG_LEVEL_INFO, "Transferred connection for " + addr);
+
+		it->second->release();
 	}
 
 	/*Connection* connection = new Connection;

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -315,7 +315,8 @@ void CryptoKernel::Network::postHandshakeConnect() {
 				if(it->second->getHandshakeSuccess()) {
 					log->printf(LOG_LEVEL_INFO, "Connection to " + key + " succeeded (client)");
 					transferConnection(key, it->second->send_cipher, it->second->recv_cipher);
-					handshakeClients.erase(key);
+					handshakeClients.clear();
+					//handshakeClients.erase(key);
 				}
 			}
 		}
@@ -328,7 +329,8 @@ void CryptoKernel::Network::postHandshakeConnect() {
 				if(it->second->getHandshakeSuccess()) {
 					log->printf(LOG_LEVEL_INFO, "Connection to " + key + " succeeded (server)");
 					transferConnection(key, it->second->sendCipher, it->second->recvCipher);
-					handshakeServers.erase(key);
+					handshakeServers.clear();
+					//handshakeServers.erase(key);
 				}
 			}
 		}

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -319,9 +319,10 @@ void CryptoKernel::Network::postHandshakeConnect() {
 					//handshakeClients.clear();
 					handshakeClients.erase(key);
 				}
-				else if(it->second->getHandshakeComplete()) {
+				else if(it->second->getHandshakeComplete() && !it->second->getHandshakeSuccess()) {
 					// handshake failed
 					handshakeClients.erase(key);
+					connectedPending.erase(key);
 				}
 			}
 		}
@@ -341,6 +342,7 @@ void CryptoKernel::Network::postHandshakeConnect() {
 				else if(it->second->getHandshakeComplete() && !it->second->getHandshakeSuccess()) {
 					// handshake failed
 					handshakeServers.erase(key);
+					connectedPending.erase(key);
 				}
 			}
 		}

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -234,10 +234,6 @@ void CryptoKernel::Network::makeOutgoingConnections(bool& wait) {
 
 		Json::Value peerInfo = it->value();
 
-		/*if(connected.contains(it->key()) || peersToQuery.contains(it->key()) 
-			|| handshakeServers.contains(it->key()) || handshakeClients.contains(it->key())) { // TODO, REMOVE OR, PROBABLY MAYBE
-			continue;
-		}*/
 		if(connected.contains(it->key()) || connectedPending.contains(it->key())) {
 			continue;
 		}

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -694,7 +694,9 @@ void CryptoKernel::Network::addToNoisePool(sf::TcpSocket* socket) {
 		}
 	}
 	else {
-		log->printf(LOG_LEVEL_INFO, "Woops. " + addr + " is already in something.");
+		log->printf(LOG_LEVEL_INFO, "Woops. " + addr + " is already inis already in something something.");
+		socket->disconnect();
+		delete socket;
 	}
 }
 

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -304,20 +304,24 @@ void CryptoKernel::Network::postHandshakeConnect() {
 		std::vector<std::string> keys = handshakeClients.keys();
 		std::random_shuffle(keys.begin(), keys.end());
 		for(std::string key: keys) {
-			auto itc = handshakeClients.find(key);
-			if(itc != handshakeClients.end()) {
-				if(itc->second->getHandshakeSuccess()) {
-					transferConnection(key, itc->second->send_cipher, itc->second->recv_cipher);
+			auto it = handshakeClients.find(key);
+			if(it != handshakeClients.end()) {
+				if(it->second->getHandshakeSuccess()) {
+					transferConnection(key, it->second->send_cipher, it->second->recv_cipher);
+					handshakeClients.erase(key);
 				}
-				continue;
 			}
-			
-			auto its = handshakeServers.find(key);
-			if(its != handshakeServers.end()) {
-				if(its->second->getHandshakeSuccess()) {
-					transferConnection(key, itc->second->send_cipher, itc->second->recv_cipher);
+		}
+
+		keys = handshakeServers.keys();
+		std::random_shuffle(keys.begin(), keys.end());
+		for(std::string key: keys) {
+			auto it = handshakeServers.find(key);
+			if(it != handshakeServers.end()) {
+				if(it->second->getHandshakeSuccess()) {
+					transferConnection(key, it->second->sendCipher, it->second->recvCipher);
+					handshakeServers.erase(key);
 				}
-				continue;
 			}
 		}
 
@@ -326,6 +330,7 @@ void CryptoKernel::Network::postHandshakeConnect() {
 }
 
 void CryptoKernel::Network::transferConnection(std::string addr, NoiseCipherState* send_cipher, NoiseCipherState* recv_cipher) {
+	log->printf(LOG_LEVEL_INFO, "Transferring connection for " + addr);
 	auto it = connectedPending.find(addr);
 	if(it != connectedPending.end()) {
 		it->second.swap(connected.at(addr));

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -307,8 +307,8 @@ void CryptoKernel::Network::postHandshakeConnect() {
 			auto it = handshakeClients.find(key);
 			if(it != handshakeClients.end()) {
 				if(it->second->getHandshakeSuccess()) {
-					transferConnection(key, it->second->send_cipher, it->second->recv_cipher);
-					handshakeClients.erase(key);
+					//transferConnection(key, it->second->send_cipher, it->second->recv_cipher);
+					//handshakeClients.erase(key);
 				}
 			}
 		}
@@ -319,8 +319,8 @@ void CryptoKernel::Network::postHandshakeConnect() {
 			auto it = handshakeServers.find(key);
 			if(it != handshakeServers.end()) {
 				if(it->second->getHandshakeSuccess()) {
-					transferConnection(key, it->second->sendCipher, it->second->recvCipher);
-					handshakeServers.erase(key);
+					//transferConnection(key, it->second->sendCipher, it->second->recvCipher);
+					//handshakeServers.erase(key);
 				}
 			}
 		}

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -180,7 +180,7 @@ CryptoKernel::Network::Network(CryptoKernel::Log* log,
 	incomingEncryptionHandshakeThread.reset(new std::thread(&CryptoKernel::Network::incomingEncryptionHandshakeWrapper, this));
 	outgoingEncryptionHandshakeThread.reset(new std::thread(&CryptoKernel::Network::outgoingEncryptionHandshakeWrapper, this));
 
-	//postHandshakeConnectThread.reset(new std::thread(&CryptoKernel::Network::postHandshakeConnect, this));
+	postHandshakeConnectThread.reset(new std::thread(&CryptoKernel::Network::postHandshakeConnect, this));
 }
 
 CryptoKernel::Network::~Network() {
@@ -192,7 +192,7 @@ CryptoKernel::Network::~Network() {
 
 	incomingEncryptionHandshakeThread->join();
 	outgoingEncryptionHandshakeThread->join();
-	//postHandshakeConnectThread->join();
+	postHandshakeConnectThread->join();
 
     listener.close();
 }

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -180,7 +180,7 @@ CryptoKernel::Network::Network(CryptoKernel::Log* log,
 	incomingEncryptionHandshakeThread.reset(new std::thread(&CryptoKernel::Network::incomingEncryptionHandshakeWrapper, this));
 	outgoingEncryptionHandshakeThread.reset(new std::thread(&CryptoKernel::Network::outgoingEncryptionHandshakeWrapper, this));
 
-	postHandshakeConnectThread.reset(new std::thread(&CryptoKernel::Network::postHandshakeConnect, this));
+	//postHandshakeConnectThread.reset(new std::thread(&CryptoKernel::Network::postHandshakeConnect, this));
 }
 
 CryptoKernel::Network::~Network() {
@@ -192,7 +192,7 @@ CryptoKernel::Network::~Network() {
 
 	incomingEncryptionHandshakeThread->join();
 	outgoingEncryptionHandshakeThread->join();
-	postHandshakeConnectThread->join();
+	//postHandshakeConnectThread->join();
 
     listener.close();
 }

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -342,11 +342,12 @@ void CryptoKernel::Network::transferConnection(std::string addr, NoiseCipherStat
 	auto it = connectedPending.find(addr);
 	if(it != connectedPending.end() && it->second->acquire()) {
 		log->printf(LOG_LEVEL_INFO, "CONNECTION VERSION 1: " + it->second->getPeerStats().version);
-		Connection* connection = std::move(it->second.get());
+		Connection* connection = it->second.get();
+		it->second.release();
 		log->printf(LOG_LEVEL_INFO, "CONNECTION VERSION 2: " + connection->getPeerStats().version);
 		connected.at(addr).reset(connection);
-		it->second->release();
-		//connectedPending.erase(addr);
+		connectedPending.erase(addr);
+		connection->release();
 
 		log->printf(LOG_LEVEL_INFO, "Transferred connection for " + addr);
 	}

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -312,6 +312,7 @@ void CryptoKernel::Network::postHandshakeConnect() {
 		for(std::string key: keys) {
 			auto it = handshakeClients.find(key);
 			if(it != handshakeClients.end()) {
+				std::lock_guard<std::mutex> hsm(handshakeMutex);
 				if(it->second->getHandshakeSuccess()) {
 					log->printf(LOG_LEVEL_INFO, "Connection to " + key + " succeeded (client)");
 					transferConnection(key, it->second->send_cipher, it->second->recv_cipher);
@@ -330,6 +331,7 @@ void CryptoKernel::Network::postHandshakeConnect() {
 		for(std::string key: keys) {
 			auto it = handshakeServers.find(key);
 			if(it != handshakeServers.end()) {
+				std::lock_guard<std::mutex> hsm(handshakeMutex);
 				if(it->second->getHandshakeSuccess()) {
 					log->printf(LOG_LEVEL_INFO, "Connection to " + key + " succeeded (server)");
 					transferConnection(key, it->second->sendCipher, it->second->recvCipher);
@@ -684,11 +686,13 @@ void CryptoKernel::Network::outgoingEncryptionHandshakeFunc() {
 }
 
 void CryptoKernel::Network::addToNoisePool(sf::TcpSocket* socket) {
-	log->printf(LOG_LEVEL_INFO, "adding " + socket->getRemoteAddress().toString() + " to noise");
+	//log->printf(LOG_LEVEL_INFO, "adding " + socket->getRemoteAddress().toString() + " to noise");
 
 	std::lock_guard<std::mutex> hsm(handshakeMutex);
 
 	std::string addr = socket->getRemoteAddress().toString();
+
+	log->printf(LOG_LEVEL_INFO, "adding " + addr + " to noise");
 
 	if(!handshakeServers.contains(addr) && !handshakeClients.contains(addr) && !connected.contains(addr)) {
 		log->printf(LOG_LEVEL_INFO, "We made it through the handshake membership test.");

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -223,7 +223,8 @@ void CryptoKernel::Network::makeOutgoingConnections(bool& wait) {
 
 		Json::Value peerInfo = it->value();
 
-		if(connected.contains(it->key()) || peersToQuery.contains(it->key())) { // TODO, REMOVE OR, PROBABLY MAYBE
+		if(connected.contains(it->key()) || peersToQuery.contains(it->key()) 
+			|| handshakeServers.contains(it->key()) || handshakeClients.contains(it->key())) { // TODO, REMOVE OR, PROBABLY MAYBE
 			continue;
 		}
 
@@ -586,9 +587,9 @@ void CryptoKernel::Network::outgoingEncryptionHandshakeFunc() {
 			//plaintextHosts.insert(addr, true);
 			continue;
 		}
-		peersToQuery.erase(addr);
 		client->setBlocking(false);
 		addToNoisePool(client);
+		peersToQuery.erase(addr);
 	}
 }
 

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -238,6 +238,7 @@ void CryptoKernel::Network::makeOutgoingConnections(bool& wait) {
 			|| handshakeServers.contains(it->key()) || handshakeClients.contains(it->key())) { // TODO, REMOVE OR, PROBABLY MAYBE
 			continue;
 		}
+		log->printf(LOG_LEVEL_INFO, "Welp, it appears that nothing contains " + it->key());
 
 		std::time_t result = std::time(nullptr);
 
@@ -308,8 +309,8 @@ void CryptoKernel::Network::postHandshakeConnect() {
 			if(it != handshakeClients.end()) {
 				if(it->second->getHandshakeSuccess()) {
 					log->printf(LOG_LEVEL_INFO, "Connection to " + key + " succeeded (client)");
-					//transferConnection(key, it->second->send_cipher, it->second->recv_cipher);
-					//handshakeClients.erase(key);
+					transferConnection(key, it->second->send_cipher, it->second->recv_cipher);
+					handshakeClients.erase(key);
 				}
 			}
 		}
@@ -321,8 +322,8 @@ void CryptoKernel::Network::postHandshakeConnect() {
 			if(it != handshakeServers.end()) {
 				if(it->second->getHandshakeSuccess()) {
 					log->printf(LOG_LEVEL_INFO, "Connection to " + key + " succeeded (server)");
-					//transferConnection(key, it->second->sendCipher, it->second->recvCipher);
-					//handshakeServers.erase(key);
+					transferConnection(key, it->second->sendCipher, it->second->recvCipher);
+					handshakeServers.erase(key);
 				}
 			}
 		}
@@ -692,7 +693,7 @@ void CryptoKernel::Network::connectionFunc() {
                 continue;
             }
 
-            if(connected.contains(client->getRemoteAddress().toString())) {
+            if(connected.contains(client->getRemoteAddress().toString()) || connectedPending.contains(client->getRemoteAddress().toString())) {
                 log->printf(LOG_LEVEL_INFO,
                             "Network(): Incoming connection duplicates existing connection for " +
                             client->getRemoteAddress().toString());

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -706,9 +706,9 @@ void CryptoKernel::Network::addToNoisePool(sf::TcpSocket* socket) {
 		}
 	}
 	else {
-		log->printf(LOG_LEVEL_INFO, "Woops. " + addr + " is already inis already in something something.");
-		socket->disconnect();
-		delete socket;
+		log->printf(LOG_LEVEL_INFO, "Woops. " + addr + " is already in something.");
+		//socket->disconnect();
+		//delete socket;
 	}
 }
 

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -374,6 +374,9 @@ void CryptoKernel::Network::infoOutgoingConnections() {
 	for(auto key: keys) {
 		auto it = connected.find(key);
 		log->printf(LOG_LEVEL_INFO, "Querying " + key + " for info");
+		if(it != connected.end()) {
+			log->printf(LOG_LEVEL_INFO, "it isn't he end");
+		}
 		if(it != connected.end() && it->second->acquire()) {
 			log->printf(LOG_LEVEL_INFO, "The querying process for " + key + " can begin.");
 			try {

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -315,8 +315,8 @@ void CryptoKernel::Network::postHandshakeConnect() {
 				if(it->second->getHandshakeSuccess()) {
 					log->printf(LOG_LEVEL_INFO, "Connection to " + key + " succeeded (client)");
 					transferConnection(key, it->second->send_cipher, it->second->recv_cipher);
-					handshakeClients.clear();
-					//handshakeClients.erase(key);
+					//handshakeClients.clear();
+					handshakeClients.erase(key);
 				}
 			}
 		}
@@ -329,8 +329,8 @@ void CryptoKernel::Network::postHandshakeConnect() {
 				if(it->second->getHandshakeSuccess()) {
 					log->printf(LOG_LEVEL_INFO, "Connection to " + key + " succeeded (server)");
 					transferConnection(key, it->second->sendCipher, it->second->recvCipher);
-					handshakeServers.clear();
-					//handshakeServers.erase(key);
+					//handshakeServers.clear();
+					handshakeServers.erase(key);
 				}
 			}
 		}

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -334,6 +334,7 @@ void CryptoKernel::Network::transferConnection(std::string addr, NoiseCipherStat
 	auto it = connectedPending.find(addr);
 	if(it != connectedPending.end()) {
 		connected.at(addr).reset(std::move(it->second.get()));
+		log->printf(LOG_LEVEL_INFO, "Transferred connection for " + addr);
 	}
 
 	/*Connection* connection = new Connection;

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -333,7 +333,7 @@ void CryptoKernel::Network::transferConnection(std::string addr, NoiseCipherStat
 	log->printf(LOG_LEVEL_INFO, "Transferring connection for " + addr);
 	auto it = connectedPending.find(addr);
 	if(it != connectedPending.end()) {
-		it->second.swap(connected.at(addr));
+		connected.at(addr).reset(std::move(it->second.get()));
 	}
 
 	/*Connection* connection = new Connection;

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -241,7 +241,7 @@ void CryptoKernel::Network::makeOutgoingConnections(bool& wait) {
 		if(connected.contains(it->key()) || connectedPending.contains(it->key())) {
 			continue;
 		}
-		log->printf(LOG_LEVEL_INFO, "Welp, it appears that nothing contains " + it->key());
+		//log->printf(LOG_LEVEL_INFO, "Welp, it appears that nothing contains " + it->key());
 
 		std::time_t result = std::time(nullptr);
 

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -333,7 +333,11 @@ void CryptoKernel::Network::transferConnection(std::string addr, NoiseCipherStat
 	log->printf(LOG_LEVEL_INFO, "Transferring connection for " + addr);
 	auto it = connectedPending.find(addr);
 	if(it != connectedPending.end()) {
-		connected.at(addr).reset(std::move(it->second.get()));
+		Connection* connection = std::move(it->second.get());
+		log->printf(LOG_LEVEL_INFO, "CONNECTION VERSION: " + connection->getPeerStats().version);
+		connectedPending.erase(addr);
+		connected.at(addr).reset(connection);
+
 		log->printf(LOG_LEVEL_INFO, "Transferred connection for " + addr);
 	}
 
@@ -662,7 +666,7 @@ void CryptoKernel::Network::addToNoisePool(std::shared_ptr<sf::TcpSocket> socket
 
 	std::string addr = socket->getRemoteAddress().toString();
 
-	if(!handshakeServers.contains(addr) && !handshakeClients.contains(addr)) {
+	if(!handshakeServers.contains(addr) && !handshakeClients.contains(addr) && !connected.contains(addr)) {
 		if(addr < myAddress.toString()) {
 			log->printf(LOG_LEVEL_INFO, "Network(): Adding a noise client (to handshakeServers), " + addr);
 			handshakeServers.at(addr).reset(new NoiseServer(socket, 8888, log));

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -340,7 +340,7 @@ void CryptoKernel::Network::postHandshakeConnect() {
 void CryptoKernel::Network::transferConnection(std::string addr, NoiseCipherState* send_cipher, NoiseCipherState* recv_cipher) {
 	log->printf(LOG_LEVEL_INFO, "Transferring connection for " + addr);
 	auto it = connectedPending.find(addr);
-	if(it != connectedPending.end() && it->second->acquire()) {
+	if(it->second && it != connectedPending.end() && it->second->acquire()) {
 		log->printf(LOG_LEVEL_INFO, "CONNECTION VERSION 1: " + it->second->getPeerStats().version);
 		Connection* connection = it->second.get();
 		it->second.release();
@@ -377,7 +377,7 @@ void CryptoKernel::Network::infoOutgoingConnections() {
 		auto it = connected.find(key);
 		log->printf(LOG_LEVEL_INFO, "Querying " + key + " for info");
 		if(it != connected.end()) {
-			log->printf(LOG_LEVEL_INFO, "it isn't he end");
+			log->printf(LOG_LEVEL_INFO, "it isn't the end");
 		}
 		if(it != connected.end() && it->second->acquire()) {
 			log->printf(LOG_LEVEL_INFO, "The querying process for " + key + " can begin.");

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -318,6 +318,10 @@ void CryptoKernel::Network::postHandshakeConnect() {
 					//handshakeClients.clear();
 					handshakeClients.erase(key);
 				}
+				else if(it->second->getHandshakeComplete()) {
+					// handshake failed
+					handshakeClients.erase(key);
+				}
 			}
 		}
 
@@ -330,6 +334,10 @@ void CryptoKernel::Network::postHandshakeConnect() {
 					log->printf(LOG_LEVEL_INFO, "Connection to " + key + " succeeded (server)");
 					transferConnection(key, it->second->sendCipher, it->second->recvCipher);
 					//handshakeServers.clear();
+					handshakeServers.erase(key);
+				}
+				else if(it->second->getHandshakeComplete() && !it->second->getHandshakeSuccess()) {
+					// handshake failed
 					handshakeServers.erase(key);
 				}
 			}

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -768,6 +768,7 @@ void CryptoKernel::Network::connectionFunc() {
             connection->setInfo("score", 0);
 
             connectedPending.at(client->getRemoteAddress().toString()).reset(connection);
+			peersToQuery.insert(std::make_pair(client->getRemoteAddress().toString(), true));
 
             /*std::unique_ptr<Storage::Transaction> dbTx(networkdb->begin());
             peers->put(dbTx.get(), client->getRemoteAddress().toString(), connection->getCachedInfo());

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -707,8 +707,8 @@ void CryptoKernel::Network::addToNoisePool(sf::TcpSocket* socket) {
 	}
 	else {
 		log->printf(LOG_LEVEL_INFO, "Woops. " + addr + " is already in something.");
-		//socket->disconnect();
-		//delete socket;
+		socket->disconnect();
+		delete socket;
 	}
 }
 

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -669,7 +669,7 @@ void CryptoKernel::Network::outgoingEncryptionHandshakeFunc() {
 			continue;
 		}
 		log->printf(LOG_LEVEL_INFO, "Connection attempt to " + addr + " is complete.");
-		client->setBlocking(false);
+		//client->setBlocking(false); abc
 		addToNoisePool(client);
 		peersToQuery.erase(addr);
 	}

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -205,7 +205,7 @@ void CryptoKernel::Network::makeOutgoingConnectionsWrapper() {
 			std::this_thread::sleep_for(std::chrono::seconds(20)); // stop looking for a while
 		}
 		else {
-			std::this_thread::sleep_for(std::chrono::milliseconds(100));
+			std::this_thread::sleep_for(std::chrono::milliseconds(4000));
 		}
 	}
 }
@@ -373,10 +373,10 @@ void CryptoKernel::Network::infoOutgoingConnections() {
 		auto it = connected.find(key);
 		log->printf(LOG_LEVEL_INFO, "Querying " + key + " for info");
 		if(it != connected.end()) {
-			log->printf(LOG_LEVEL_INFO, "it isn't the end");
+			//log->printf(LOG_LEVEL_INFO, "it isn't the end");
 		}
 		if(it != connected.end() && it->second->acquire()) {
-			log->printf(LOG_LEVEL_INFO, "The querying process for " + key + " can begin.");
+			//log->printf(LOG_LEVEL_INFO, "The querying process for " + key + " can begin.");
 			try {
 				const Json::Value info = it->second->getInfo();
 				try {

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -596,7 +596,7 @@ void CryptoKernel::Network::addToNoisePool(std::shared_ptr<sf::TcpSocket> socket
 		}
 		else {
 			log->printf(LOG_LEVEL_INFO, "Network(): Added connection to handshake clients: " + addr);
-			handshakeClients.at(addr).reset(new NoiseClient(socket, socket->getRemoteAddress().toString(), 88, log));
+			handshakeClients.at(addr).reset(new NoiseClient(socket, addr, 88, log));
 		}
 	}
 }

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -636,8 +636,8 @@ void CryptoKernel::Network::incomingEncryptionHandshakeWrapper() {
 void CryptoKernel::Network::incomingEncryptionHandshakeFunc(sf::TcpListener& ls, sf::SocketSelector& selector) {
 	if(selector.wait(sf::seconds(2))) {
 		if(selector.isReady(ls)) { // don't need this outer if anymore
-			std::shared_ptr<sf::TcpSocket> client(new sf::TcpSocket);
-			if(ls.accept(*client.get()) == sf::Socket::Done) {
+			sf::TcpSocket* client = new sf::TcpSocket();
+			if(ls.accept(*client) == sf::Socket::Done) {
 				std::string addr = client->getRemoteAddress().toString();
 				log->printf(LOG_LEVEL_INFO, "Network(): Connection accepted from " + addr);
 				addToNoisePool(client);
@@ -657,7 +657,7 @@ void CryptoKernel::Network::outgoingEncryptionHandshakeFunc() {
 	std::random_shuffle(addresses.begin(), addresses.end());
 
 	for(std::string addr : addresses) {
-		std::shared_ptr<sf::TcpSocket> client(new sf::TcpSocket());
+		sf::TcpSocket* client = new sf::TcpSocket();
 		//client->setBlocking(false); // Ultimately, it would be better to do this HERE instead of below, but it makes things more complicated
 		log->printf(LOG_LEVEL_INFO, "Network(): Attempting to connect to " + addr + " to query encryption preference.");
 		if(client->connect(addr, port + 1, sf::seconds(3)) != sf::Socket::Done) {
@@ -672,7 +672,7 @@ void CryptoKernel::Network::outgoingEncryptionHandshakeFunc() {
 	}
 }
 
-void CryptoKernel::Network::addToNoisePool(std::shared_ptr<sf::TcpSocket> socket) {
+void CryptoKernel::Network::addToNoisePool(sf::TcpSocket* socket) {
 	std::lock_guard<std::mutex> hsm(handshakeMutex);
 
 	std::string addr = socket->getRemoteAddress().toString();

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -333,8 +333,9 @@ void CryptoKernel::Network::transferConnection(std::string addr, NoiseCipherStat
 	log->printf(LOG_LEVEL_INFO, "Transferring connection for " + addr);
 	auto it = connectedPending.find(addr);
 	if(it != connectedPending.end()) {
+		log->printf(LOG_LEVEL_INFO, "CONNECTION VERSION 1: " + it->second->getPeerStats().version);
 		Connection* connection = std::move(it->second.get());
-		log->printf(LOG_LEVEL_INFO, "CONNECTION VERSION: " + connection->getPeerStats().version);
+		log->printf(LOG_LEVEL_INFO, "CONNECTION VERSION 2: " + connection->getPeerStats().version);
 		connectedPending.erase(addr);
 		connected.at(addr).reset(connection);
 

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -342,8 +342,8 @@ void CryptoKernel::Network::transferConnection(std::string addr, NoiseCipherStat
 		log->printf(LOG_LEVEL_INFO, "CONNECTION VERSION 1: " + it->second->getPeerStats().version);
 		Connection* connection = std::move(it->second.get());
 		log->printf(LOG_LEVEL_INFO, "CONNECTION VERSION 2: " + connection->getPeerStats().version);
-		connectedPending.erase(addr);
 		connected.at(addr).reset(connection);
+		connectedPending.erase(addr);
 
 		log->printf(LOG_LEVEL_INFO, "Transferred connection for " + addr);
 	}

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -234,8 +234,11 @@ void CryptoKernel::Network::makeOutgoingConnections(bool& wait) {
 
 		Json::Value peerInfo = it->value();
 
-		if(connected.contains(it->key()) || peersToQuery.contains(it->key()) 
+		/*if(connected.contains(it->key()) || peersToQuery.contains(it->key()) 
 			|| handshakeServers.contains(it->key()) || handshakeClients.contains(it->key())) { // TODO, REMOVE OR, PROBABLY MAYBE
+			continue;
+		}*/
+		if(connected.contains(it->key()) || connectedPending.contains(it->key())) {
 			continue;
 		}
 		log->printf(LOG_LEVEL_INFO, "Welp, it appears that nothing contains " + it->key());

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -371,6 +371,7 @@ void CryptoKernel::Network::infoOutgoingConnections() {
 	std::random_shuffle(keys.begin(), keys.end());
 	for(auto key: keys) {
 		auto it = connected.find(key);
+		log->printf(LOG_LEVEL_INFO, "Querying " + key + " for info");
 		if(it != connected.end() && it->second->acquire()) {
 			try {
 				const Json::Value info = it->second->getInfo();
@@ -456,6 +457,7 @@ void CryptoKernel::Network::networkFunc() {
         for(auto key : keys) {
         	auto it = connected.find(key);
         	if(it != connected.end() && it->second->acquire()) {
+				log->printf(LOG_LEVEL_INFO, "Looking at " + key);
                 defer d([&]{it->second->release();});
         		if(it->second->getInfo("height").asUInt64() > bestHeight) {
 					bestHeight = it->second->getInfo("height").asUInt64();

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -346,7 +346,7 @@ void CryptoKernel::Network::transferConnection(std::string addr, NoiseCipherStat
 		log->printf(LOG_LEVEL_INFO, "CONNECTION VERSION 2: " + connection->getPeerStats().version);
 		connected.at(addr).reset(connection);
 		it->second->release();
-		connectedPending.erase(addr);
+		//connectedPending.erase(addr);
 
 		log->printf(LOG_LEVEL_INFO, "Transferred connection for " + addr);
 	}

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -307,6 +307,7 @@ void CryptoKernel::Network::postHandshakeConnect() {
 			auto it = handshakeClients.find(key);
 			if(it != handshakeClients.end()) {
 				if(it->second->getHandshakeSuccess()) {
+					log->printf(LOG_LEVEL_INFO, "Connection to " + key + " succeeded (client)");
 					//transferConnection(key, it->second->send_cipher, it->second->recv_cipher);
 					//handshakeClients.erase(key);
 				}
@@ -319,6 +320,7 @@ void CryptoKernel::Network::postHandshakeConnect() {
 			auto it = handshakeServers.find(key);
 			if(it != handshakeServers.end()) {
 				if(it->second->getHandshakeSuccess()) {
+					log->printf(LOG_LEVEL_INFO, "Connection to " + key + " succeeded (server)");
 					//transferConnection(key, it->second->sendCipher, it->second->recvCipher);
 					//handshakeServers.erase(key);
 				}

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -375,6 +375,7 @@ void CryptoKernel::Network::infoOutgoingConnections() {
 		auto it = connected.find(key);
 		log->printf(LOG_LEVEL_INFO, "Querying " + key + " for info");
 		if(it != connected.end() && it->second->acquire()) {
+			log->printf(LOG_LEVEL_INFO, "The querying process for " + key + " can begin.");
 			try {
 				const Json::Value info = it->second->getInfo();
 				try {

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -166,16 +166,16 @@ CryptoKernel::Network::Network(CryptoKernel::Log* log,
     std::srand(seed);
 
     // Start connection thread
-    //connectionThread.reset(new std::thread(&CryptoKernel::Network::connectionFunc, this));
+    connectionThread.reset(new std::thread(&CryptoKernel::Network::connectionFunc, this));
 
     // Start management thread
-    //networkThread.reset(new std::thread(&CryptoKernel::Network::networkFunc, this));
+    networkThread.reset(new std::thread(&CryptoKernel::Network::networkFunc, this));
 
     // Start peer thread
    	makeOutgoingConnectionsThread.reset(new std::thread(&CryptoKernel::Network::makeOutgoingConnectionsWrapper, this));
 
     // Start peer thread
-    //infoOutgoingConnectionsThread.reset(new std::thread(&CryptoKernel::Network::infoOutgoingConnectionsWrapper, this));
+    infoOutgoingConnectionsThread.reset(new std::thread(&CryptoKernel::Network::infoOutgoingConnectionsWrapper, this));
 
 	incomingEncryptionHandshakeThread.reset(new std::thread(&CryptoKernel::Network::incomingEncryptionHandshakeWrapper, this));
 	outgoingEncryptionHandshakeThread.reset(new std::thread(&CryptoKernel::Network::outgoingEncryptionHandshakeWrapper, this));
@@ -185,10 +185,10 @@ CryptoKernel::Network::Network(CryptoKernel::Log* log,
 
 CryptoKernel::Network::~Network() {
     running = false;
-    //connectionThread->join();
-    //networkThread->join();
+    connectionThread->join();
+    networkThread->join();
     makeOutgoingConnectionsThread->join();
-    //infoOutgoingConnectionsThread->join();
+    infoOutgoingConnectionsThread->join();
 
 	incomingEncryptionHandshakeThread->join();
 	outgoingEncryptionHandshakeThread->join();

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -668,6 +668,7 @@ void CryptoKernel::Network::outgoingEncryptionHandshakeFunc() {
 			plaintextHosts.insert(addr, true);
 			continue;
 		}
+		log->printf(LOG_LEVEL_INFO, "Connection attempt to " + addr + " is complete.");
 		client->setBlocking(false);
 		addToNoisePool(client);
 		peersToQuery.erase(addr);
@@ -675,11 +676,14 @@ void CryptoKernel::Network::outgoingEncryptionHandshakeFunc() {
 }
 
 void CryptoKernel::Network::addToNoisePool(sf::TcpSocket* socket) {
+	log->printf(LOG_LEVEL_INFO, "adding " + socket->getRemoteAddress().toString() + " to noise");
+
 	std::lock_guard<std::mutex> hsm(handshakeMutex);
 
 	std::string addr = socket->getRemoteAddress().toString();
 
 	if(!handshakeServers.contains(addr) && !handshakeClients.contains(addr) && !connected.contains(addr)) {
+		log->printf(LOG_LEVEL_INFO, "We made it through the handshake membership test.");
 		if(addr < myAddress.toString()) {
 			log->printf(LOG_LEVEL_INFO, "Network(): Adding a noise client (to handshakeServers), " + addr);
 			handshakeServers.at(addr).reset(new NoiseServer(socket, 8888, log));
@@ -688,6 +692,9 @@ void CryptoKernel::Network::addToNoisePool(sf::TcpSocket* socket) {
 			log->printf(LOG_LEVEL_INFO, "Network(): Added connection to handshake clients: " + addr);
 			handshakeClients.at(addr).reset(new NoiseClient(socket, addr, 88, log));
 		}
+	}
+	else {
+		log->printf(LOG_LEVEL_INFO, "Woops. " + addr + " is already in something.");
 	}
 }
 

--- a/src/kernel/network.h
+++ b/src/kernel/network.h
@@ -175,7 +175,7 @@ private:
     void outgoingEncryptionHandshakeFunc();
 	std::unique_ptr<std::thread> outgoingEncryptionHandshakeThread;
 
-    void addToNoisePool(std::shared_ptr<sf::TcpSocket> socket);
+    void addToNoisePool(sf::TcpSocket* socket);
 
     void postHandshakeConnect();
     std::unique_ptr<std::thread> postHandshakeConnectThread;

--- a/src/kernel/network.h
+++ b/src/kernel/network.h
@@ -170,10 +170,9 @@ private:
 
     void outgoingEncryptionHandshakeWrapper();
     void outgoingEncryptionHandshakeFunc();
+	std::unique_ptr<std::thread> outgoingEncryptionHandshakeThread;
 
     void addToNoisePool(std::shared_ptr<sf::TcpSocket> socket);
-
-	std::unique_ptr<std::thread> outgoingEncryptionHandshakeThread;
 
     std::mutex handshakeMutex;
     ConcurrentMap<std::string, std::unique_ptr<NoiseClient>> handshakeClients;

--- a/src/kernel/network.h
+++ b/src/kernel/network.h
@@ -171,8 +171,6 @@ private:
     void outgoingEncryptionHandshakeWrapper();
     void outgoingEncryptionHandshakeFunc();
 
-    void receiveNoisePackets(sf::SocketSelector& selector);
-
     void addToNoisePool(std::shared_ptr<sf::TcpSocket> socket);
 
 	std::unique_ptr<std::thread> outgoingEncryptionHandshakeThread;

--- a/src/kernel/network.h
+++ b/src/kernel/network.h
@@ -183,6 +183,7 @@ private:
     std::mutex handshakeMutex;
     ConcurrentMap<std::string, std::unique_ptr<NoiseClient>> handshakeClients;
     ConcurrentMap<std::string, std::unique_ptr<NoiseServer>> handshakeServers;
+    ConcurrentMap<std::string, bool> plaintextHosts;
     ConcurrentMap<std::string, bool> peersToQuery; // (regarding encyrption preference)
     ConcurrentMap<std::string, std::unique_ptr<Connection>> connectedPending; // connections we've made but aren't yet ready to use
     sf::TcpListener listener;

--- a/src/kernel/network.h
+++ b/src/kernel/network.h
@@ -127,6 +127,9 @@ private:
 		Json::Value getCachedInfo();
 		Network::peerStats getPeerStats() const;
 
+        void setSendCipher(NoiseCipherState* cipher);
+		void setRecvCipher(NoiseCipherState* cipher);
+
     	~Connection();
 
     private:
@@ -174,14 +177,19 @@ private:
 
     void addToNoisePool(std::shared_ptr<sf::TcpSocket> socket);
 
+    void postHandshakeConnect();
+
     std::mutex handshakeMutex;
     ConcurrentMap<std::string, std::unique_ptr<NoiseClient>> handshakeClients;
     ConcurrentMap<std::string, std::unique_ptr<NoiseServer>> handshakeServers;
     ConcurrentMap<std::string, bool> peersToQuery; // (regarding encyrption preference)
+    ConcurrentMap<std::string, std::unique_ptr<Connection>> connectedPending; // connections we've made but aren't yet ready to use
     sf::TcpListener listener;
 
     ConcurrentMap<std::string, uint64_t> banned;
 
+    void addConnection(sf::TcpSocket* socket, Json::Value& peerInfo, NoiseCipherState* send_cipher=0, NoiseCipherState* recv_cipher=0);
+    
     sf::IpAddress myAddress;
 
     uint64_t bestHeight;

--- a/src/kernel/network.h
+++ b/src/kernel/network.h
@@ -9,6 +9,8 @@
 
 #include "blockchain.h"
 #include "concurrentmap.h"
+#include "NoiseServer.h"
+#include "NoiseClient.h"
 
 namespace CryptoKernel {
 /**
@@ -162,6 +164,23 @@ private:
     void infoOutgoingConnectionsWrapper();
     std::unique_ptr<std::thread> infoOutgoingConnectionsThread;
 
+    void incomingEncryptionHandshakeWrapper();
+    void incomingEncryptionHandshakeFunc(sf::TcpListener& ls, sf::SocketSelector& selector);
+    std::unique_ptr<std::thread> incomingEncryptionHandshakeThread;
+
+    void outgoingEncryptionHandshakeWrapper();
+    void outgoingEncryptionHandshakeFunc();
+
+    void receiveNoisePackets(sf::SocketSelector& selector);
+
+    void addToNoisePool(std::shared_ptr<sf::TcpSocket> socket);
+
+	std::unique_ptr<std::thread> outgoingEncryptionHandshakeThread;
+
+    std::mutex handshakeMutex;
+    ConcurrentMap<std::string, std::unique_ptr<NoiseClient>> handshakeClients;
+    ConcurrentMap<std::string, std::unique_ptr<NoiseServer>> handshakeServers;
+    ConcurrentMap<std::string, bool> peersToQuery; // (regarding encyrption preference)
     sf::TcpListener listener;
 
     ConcurrentMap<std::string, uint64_t> banned;

--- a/src/kernel/network.h
+++ b/src/kernel/network.h
@@ -178,6 +178,7 @@ private:
     void addToNoisePool(std::shared_ptr<sf::TcpSocket> socket);
 
     void postHandshakeConnect();
+    std::unique_ptr<std::thread> postHandshakeConnectThread;
 
     std::mutex handshakeMutex;
     ConcurrentMap<std::string, std::unique_ptr<NoiseClient>> handshakeClients;
@@ -188,7 +189,7 @@ private:
 
     ConcurrentMap<std::string, uint64_t> banned;
 
-    void addConnection(sf::TcpSocket* socket, Json::Value& peerInfo, NoiseCipherState* send_cipher=0, NoiseCipherState* recv_cipher=0);
+    void transferConnection(std::string addr, NoiseCipherState* send_cipher=0, NoiseCipherState* recv_cipher=0);
     
     sf::IpAddress myAddress;
 

--- a/src/kernel/network.h
+++ b/src/kernel/network.h
@@ -112,7 +112,7 @@ private:
 		std::vector<CryptoKernel::Blockchain::transaction> getUnconfirmedTransactions();
 		CryptoKernel::Blockchain::block getBlock(const uint64_t height, const std::string& id);
 		std::vector<CryptoKernel::Blockchain::block> getBlocks(const uint64_t start, const uint64_t end);
-    CryptoKernel::Network::peerStats getPeerStats();
+        CryptoKernel::Network::peerStats getPeerStats();
 
 		bool acquire();
 		void release();

--- a/src/kernel/networkpeer.cpp
+++ b/src/kernel/networkpeer.cpp
@@ -4,7 +4,7 @@
 #include "networkpeer.h"
 
 CryptoKernel::Network::Peer::Peer(sf::TcpSocket* client, CryptoKernel::Blockchain* blockchain,
-                                  CryptoKernel::Network* network, const bool incoming) {
+                                  CryptoKernel::Network* network, const bool incoming, CryptoKernel::Log* log) {
     this->client = client;
     this->blockchain = blockchain;
     this->network = network;
@@ -21,7 +21,20 @@ CryptoKernel::Network::Peer::Peer(sf::TcpSocket* client, CryptoKernel::Blockchai
 
     client->setBlocking(true);
 
+    send_cipher = 0;
+    recv_cipher = 0;
+
+    this->log = log;
+
     requestThread.reset(new std::thread(&CryptoKernel::Network::Peer::requestFunc, this));
+}
+
+void CryptoKernel::Network::Peer::setSendCipher(NoiseCipherState* cipher) {
+	this->send_cipher = cipher;
+}
+
+void CryptoKernel::Network::Peer::setRecvCipher(NoiseCipherState* cipher) {
+	this->recv_cipher = cipher;
 }
 
 CryptoKernel::Network::Peer::~Peer() {

--- a/src/kernel/networkpeer.h
+++ b/src/kernel/networkpeer.h
@@ -11,7 +11,7 @@
 class CryptoKernel::Network::Peer {
 public:
     Peer(sf::TcpSocket* client, CryptoKernel::Blockchain* blockchain,
-         CryptoKernel::Network* network, const bool incoming);
+         CryptoKernel::Network* network, const bool incoming, CryptoKernel::Log* log);
     ~Peer();
 
     Json::Value getInfo();
@@ -38,7 +38,11 @@ public:
         std::string msg;
     };
 
+    void setSendCipher(NoiseCipherState* cipher);
+    void setRecvCipher(NoiseCipherState* cipher);
+
 private:
+    CryptoKernel::Log* log;
     sf::TcpSocket* client;
     CryptoKernel::Blockchain* blockchain;
     CryptoKernel::Network* network;
@@ -57,6 +61,9 @@ private:
     std::default_random_engine generator;
     
     Network::peerStats stats;
+
+    NoiseCipherState* send_cipher;
+	NoiseCipherState* recv_cipher;
 };
 
 #endif // NETWORKPEER_H_INCLUDED

--- a/src/kernel/networkpeer.h
+++ b/src/kernel/networkpeer.h
@@ -23,6 +23,9 @@ public:
     std::vector<CryptoKernel::Blockchain::block> getBlocks(const uint64_t start,
                                                            const uint64_t end);
     
+    void prepPacket(sf::Packet& packet, std::string data);
+    sf::Packet decryptPacket(sf::Packet& packet);
+
     Network::peerStats getPeerStats() const;
 
     class NetworkError : std::exception {


### PR DESCRIPTION
So, here's another go at encrypting network traffic using noise for key exchange.  To work correctly, your CryptoKernel directory needs a "keys" folder.  There doesn't seem to be a great platform-agnostic way to create one of those, so suggestions are welcome.  Peers that support encryption let each other known on another port before exchanging any other information, but still respond normally to peers that don't.