### PR TITLE
Don't send invalid IP addresses in info messages

### DIFF
--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -329,7 +329,7 @@ void CryptoKernel::Network::infoOutgoingConnections() {
 							}
 						} else {
 							changeScore(it->first, 10);
-							throw Peer::NetworkError("peer sent a malformed peer IP address");
+							throw Peer::NetworkError("peer sent a malformed peer IP address: \"" + addr.toString() + "\"");
 						}
 					}
 				} catch(const Json::Exception& e) {

--- a/src/kernel/networkpeer.cpp
+++ b/src/kernel/networkpeer.cpp
@@ -131,7 +131,10 @@ void CryptoKernel::Network::Peer::requestFunc() {
                             response["data"]["version"] = version;
                             response["data"]["tipHeight"] = network->getCurrentHeight();
                             for(const auto& peer : network->getConnectedPeers()) {
-                                response["data"]["peers"].append(peer);
+                                sf::IpAddress addr(peer);
+                                if(addr != sf::IpAddress::None && addr != sf::IpAddress::LocalHost) {
+                                    response["data"]["peers"].append(peer);
+                                }
                             }
                             response["nonce"] = request["nonce"].asUInt64();
                             send(response);


### PR DESCRIPTION
Sometimes nodes get connected to themselves, or are unable to resolve IP addresses. In that case an IP address such as 127.0.0.1 or 0.0.0.0 might be sent, which will cause the remote peer to disconnect. Add a check for such IP addresses before adding them to the peers list to send with an info message. Also improved the log message for disconnecting a peer behaving in this way to display the offending malformed IP address.