### PR TITLE
Ensure connection lock is released before attempting to delete it

### DIFF
--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -592,7 +592,7 @@ void CryptoKernel::Network::connectionFunc() {
             } catch(const Peer::NetworkError& e) {
                 log->printf(LOG_LEVEL_WARN, "Network(): Failed to get information from connecting peer: " + std::string(e.what()));
                 connection->release();
-				delete connection;
+                delete connection;
                 continue;
             }
 
@@ -602,7 +602,7 @@ void CryptoKernel::Network::connectionFunc() {
             } catch(const Json::Exception& e) {
                 log->printf(LOG_LEVEL_WARN, "Network(): Incoming peer sent invalid info message");
                 connection->release();
-				delete connection;
+                delete connection;
                 continue;
             }
 
@@ -617,7 +617,7 @@ void CryptoKernel::Network::connectionFunc() {
             peers->put(dbTx.get(), client->getRemoteAddress().toString(), connection->getCachedInfo());
             dbTx->commit();
 
-			connection->release();
+            connection->release();
         } else {
             delete client;
         }

--- a/src/kernel/network.cpp
+++ b/src/kernel/network.cpp
@@ -583,7 +583,6 @@ void CryptoKernel::Network::connectionFunc() {
                         std::to_string(client->getRemotePort()));
             Connection* connection = new Connection();
 			connection->acquire();
-			defer d([&]{connection->release();});
             connection->setPeer(new Peer(client, blockchain, this, true));
 
             Json::Value info;
@@ -592,7 +591,8 @@ void CryptoKernel::Network::connectionFunc() {
                 info = connection->getInfo();
             } catch(const Peer::NetworkError& e) {
                 log->printf(LOG_LEVEL_WARN, "Network(): Failed to get information from connecting peer: " + std::string(e.what()));
-                delete connection;
+                connection->release();
+				delete connection;
                 continue;
             }
 
@@ -601,7 +601,8 @@ void CryptoKernel::Network::connectionFunc() {
                 connection->setInfo("version", info["version"].asString());
             } catch(const Json::Exception& e) {
                 log->printf(LOG_LEVEL_WARN, "Network(): Incoming peer sent invalid info message");
-                delete connection;
+                connection->release();
+				delete connection;
                 continue;
             }
 
@@ -615,6 +616,8 @@ void CryptoKernel::Network::connectionFunc() {
             std::unique_ptr<Storage::Transaction> dbTx(networkdb->begin());
             peers->put(dbTx.get(), client->getRemoteAddress().toString(), connection->getCachedInfo());
             dbTx->commit();
+
+			connection->release();
         } else {
             delete client;
         }


### PR DESCRIPTION
Previously defer was used here, but that did not account for attempting to delete the connection before defer is deconstructed. Therefore a deadlock was caused as to delete the connection a lock on it is required. Instead manually release the lock.