### PR TITLE
Catch script resource exceptions to prevent crashes

### DIFF
--- a/src/kernel/contract.cpp
+++ b/src/kernel/contract.cpp
@@ -137,13 +137,14 @@ bool CryptoKernel::ContractRunner::evaluateScriptValid(Storage::Transaction* dbT
     try {
         sel::tie(result, errorMessage) = (*state.get())["verifyTransaction"](base64_decode(
                                                 script));
-
-        if(errorMessage != "") {
-            return false;
-        }
-
-        return result;
     } catch(const CryptoKernel::Blockchain::InvalidElementException& e) {
         return false;
     }
+
+    if(errorMessage != "") {
+        throw std::runtime_error(errorMessage);
+
+    }
+
+    return result;
 }

--- a/src/kernel/contract.cpp
+++ b/src/kernel/contract.cpp
@@ -143,7 +143,6 @@ bool CryptoKernel::ContractRunner::evaluateScriptValid(Storage::Transaction* dbT
 
     if(errorMessage != "") {
         throw std::runtime_error(errorMessage);
-
     }
 
     return result;

--- a/src/kernel/contract.cpp
+++ b/src/kernel/contract.cpp
@@ -52,7 +52,7 @@ void* CryptoKernel::ContractRunner::l_alloc_restricted(void* ud, void* ptr, size
         return NULL;
     } else {
         if (*used + (nsize - osize) > memoryLimit) {/* too much memory in use */
-            throw std::runtime_error("Memory limit reached");
+            throw CryptoKernel::Blockchain::InvalidElementException("Memory limit reached");
         }
         ptr = realloc(ptr, nsize);
         if (ptr) {/* reallocation successful? */
@@ -119,7 +119,7 @@ bool CryptoKernel::ContractRunner::evaluateValid(Storage::Transaction* dbTx,
 bool CryptoKernel::ContractRunner::evaluateScriptValid(Storage::Transaction* dbTx,
         const CryptoKernel::Blockchain::transaction& tx,
         const CryptoKernel::Blockchain::input& inp, 
-        std::string script) {
+        const std::string& script) {
             
     setupEnvironment(dbTx, tx, inp);
     if(!(*state.get()).Load("./sandbox.lua")) {
@@ -134,12 +134,16 @@ bool CryptoKernel::ContractRunner::evaluateScriptValid(Storage::Transaction* dbT
                                         result = false;
                                     });
 
-    sel::tie(result, errorMessage) = (*state.get())["verifyTransaction"](base64_decode(
-                                            script));
+    try {
+        sel::tie(result, errorMessage) = (*state.get())["verifyTransaction"](base64_decode(
+                                                script));
 
-    if(errorMessage != "") {
-        throw std::runtime_error(errorMessage);
+        if(errorMessage != "") {
+            return false;
+        }
+
+        return result;
+    } catch(const CryptoKernel::Blockchain::InvalidElementException& e) {
+        return false;
     }
-
-    return result;
 }

--- a/src/kernel/contract.h
+++ b/src/kernel/contract.h
@@ -62,7 +62,7 @@ public:
    bool evaluateScriptValid(Storage::Transaction* dbTx,
         const CryptoKernel::Blockchain::transaction& tx,
         const CryptoKernel::Blockchain::input& inp, 
-        std::string script);
+        const std::string& script);
 private:
     void setupEnvironment(Storage::Transaction* dbTx,
                           const CryptoKernel::Blockchain::transaction& tx,

--- a/tests/ContractTests.cpp
+++ b/tests/ContractTests.cpp
@@ -199,8 +199,6 @@ void ContractTest::testToString() {
     const auto outs = blockchain->getUnspentOutputs(ECDSAPubKey);
     const auto& out = *outs.begin();
 
-    // First, spend our newly acquired coinbase output to
-    // a pay-to-merkleroot output
     Json::Value outData;
     
     // local hello = {} return tostring(hello) == \"table\"
@@ -244,8 +242,6 @@ void ContractTest::testTableIterationOrder() {
         const auto outs = blockchain->getUnspentOutputs(ECDSAPubKey);
         const auto& out = *outs.begin();
 
-        // First, spend our newly acquired coinbase output to
-        // a pay-to-merkleroot output
         Json::Value outData;
         
         // "hello = {} hello[\"test1\"] = 1 hello[\"test2\"] = 2 hello[\"test3\"] = 3 hello[\"test4\"] = 4 hello[\"test5\"] = 5 res = {} for k, v in pairs(hello) do table.insert(res, v) end return (res[1] == 3 and res[2] == 1 and res[3] == 2 and res[4] == 5 and res[5] == 4)"
@@ -288,4 +284,137 @@ void ContractTest::testTableIterationOrder() {
 
         runtest();
     }
+}
+
+void ContractTest::testSimpleError() {
+    CryptoKernel::Crypto crypto(true);
+    const auto ECDSAPubKey = crypto.getPublicKey();
+
+    consensus->mineBlock(true, ECDSAPubKey);
+
+    const auto outs = blockchain->getUnspentOutputs(ECDSAPubKey);
+    const auto& out = *outs.begin();
+
+    Json::Value outData;
+    
+    // "return \"error\""
+    outData["contract"] = "BCJNGGBAgl8AAAD2BRtMdWFTABmTDQoaCgQIBAgIeFYAAQD1BCh3QAEPcmV0dXJuICJlcnJvciIcADABAgMGAKEAAAAmAAABJgCADAAhBAYnABMBGwAkAAAlAAYSALAAAAEAAAAFX0VOVgAAAAA="; 
+    
+    CryptoKernel::Blockchain::output contractOutput(out.getValue() - 90000, 0, outData);
+
+    const std::string outputSetId = CryptoKernel::Blockchain::transaction::getOutputSetId({contractOutput}).toString();
+
+    Json::Value spendData;
+    spendData["signature"] = crypto.sign(out.getId().toString() + outputSetId);
+
+    CryptoKernel::Blockchain::input inp(out.getId(), spendData);
+    CryptoKernel::Blockchain::transaction tx({inp}, {contractOutput}, 1530888581);
+
+    const auto res = blockchain->submitTransaction(tx);
+    CPPUNIT_ASSERT_MESSAGE("Initial contract transaction failed", std::get<0>(res));
+
+    consensus->mineBlock(true, ECDSAPubKey);
+
+    // Try spending from the contract output back to our key. Should fail as the script is just 'return false'
+    Json::Value p2pkOutData;
+    p2pkOutData["publicKey"] = crypto.getPublicKey();
+    CryptoKernel::Blockchain::output p2pkout(contractOutput.getValue() - 40000, 0, p2pkOutData);
+
+    Json::Value spendData2; // empty
+    CryptoKernel::Blockchain::input contractin(contractOutput.getId(), spendData2);
+    CryptoKernel::Blockchain::transaction contractspendtx({contractin}, {p2pkout}, 1530888581);
+
+    std::tuple<bool, bool> res2;
+    CPPUNIT_ASSERT_NO_THROW_MESSAGE("Spending contract caused an exception", res2 = blockchain->submitTransaction(contractspendtx));
+    CPPUNIT_ASSERT_MESSAGE("Spending contract output succeeded. Shouldn't have.", !std::get<0>(res2));
+}
+
+void ContractTest::testMemoryLimit() {
+    CryptoKernel::Crypto crypto(true);
+    const auto ECDSAPubKey = crypto.getPublicKey();
+
+    consensus->mineBlock(true, ECDSAPubKey);
+
+    const auto outs = blockchain->getUnspentOutputs(ECDSAPubKey);
+    const auto& out = *outs.begin();
+
+    // First, spend our newly acquired coinbase output to
+    // a pay-to-merkleroot output
+    Json::Value outData;
+    
+    // "tbl = {} for i=0, 1000000, 1 do table.insert(tbl, i) end return true"
+    outData["contract"] = "BCJNGGBAgg8BAAD2BRtMdWFTABmTDQoaCgQIBAgIeFYAAQDxCih3QAFFdGJsID0ge30gZm9yIGk9MCwgMTABAPUcLCAxIGRvIHRhYmxlLmluc2VydCh0YmwsIGkpIGVuZCByZXR1cm4gdHJ1ZVIA9D0BBw8AAAALAAAACAAAgAFAAABBgAAAgcAAACgAAYAGAUEAB0FBAkYBQACAAYABJEGAASdA/n8DAIAAJgAAASYAgAAGAAAABAR0YmwTVABCE0BCDwkAEwESACEEBpUAIgQHlgAAFwACGwATDwoADwQAJWEEAAAADCgJAWBuZGV4KQUQAAUUAFVsaW1pdBQAEQsUAEVzdGVwEwAzAmkG/gCQAQAAAAVfRU5WAAAAAA=="; 
+    
+    CryptoKernel::Blockchain::output contractOutput(out.getValue() - 90000, 0, outData);
+
+    const std::string outputSetId = CryptoKernel::Blockchain::transaction::getOutputSetId({contractOutput}).toString();
+
+    Json::Value spendData;
+    spendData["signature"] = crypto.sign(out.getId().toString() + outputSetId);
+
+    CryptoKernel::Blockchain::input inp(out.getId(), spendData);
+    CryptoKernel::Blockchain::transaction tx({inp}, {contractOutput}, 1530888581);
+
+    const auto res = blockchain->submitTransaction(tx);
+    CPPUNIT_ASSERT_MESSAGE("Initial contract transaction failed", std::get<0>(res));
+
+    consensus->mineBlock(true, ECDSAPubKey);
+
+    // Try spending from the contract output back to our key. Should fail as the script is just 'return false'
+    Json::Value p2pkOutData;
+    p2pkOutData["publicKey"] = crypto.getPublicKey();
+    CryptoKernel::Blockchain::output p2pkout(contractOutput.getValue() - 40000, 0, p2pkOutData);
+
+    Json::Value spendData2; // empty
+    CryptoKernel::Blockchain::input contractin(contractOutput.getId(), spendData2);
+    CryptoKernel::Blockchain::transaction contractspendtx({contractin}, {p2pkout}, 1530888581);
+
+    std::tuple<bool, bool> res2;
+    CPPUNIT_ASSERT_NO_THROW_MESSAGE("Spending contract caused an exception", res2 = blockchain->submitTransaction(contractspendtx));
+    CPPUNIT_ASSERT_MESSAGE("Spending contract output succeeded. Shouldn't have.", !std::get<0>(res2));
+}
+
+void ContractTest::testInstructionLimit() {
+    CryptoKernel::Crypto crypto(true);
+    const auto ECDSAPubKey = crypto.getPublicKey();
+
+    consensus->mineBlock(true, ECDSAPubKey);
+
+    const auto outs = blockchain->getUnspentOutputs(ECDSAPubKey);
+    const auto& out = *outs.begin();
+
+    // First, spend our newly acquired coinbase output to
+    // a pay-to-merkleroot output
+    Json::Value outData;
+    
+    // "for i=0, 100000000, 1 do end return true"
+    outData["contract"] = "BCJNGGBAgsQAAAD2BRtMdWFTABmTDQoaCgQIBAgIeFYAAQDzASh3QAEpZm9yIGk9MCwgMTABAPUHLCAxIGRvIGVuZCByZXR1cm4gdHJ1ZTYAMAEECAYA9BUAAABBQAAAgYAAACjA/38ngP9/AwCAACYAAAEmAIAAAwAAABMzAFETAOH1BQkAFAFFAAMEACQAAE0ADwQACWEEAAAADCiqAFBuZGV4KV0AFQUUAFVsaW1pdBQAEQsUAEVzdGVwEwAzAmkERQCQAQAAAAVfRU5WAAAAAA=="; 
+    
+    CryptoKernel::Blockchain::output contractOutput(out.getValue() - 90000, 0, outData);
+
+    const std::string outputSetId = CryptoKernel::Blockchain::transaction::getOutputSetId({contractOutput}).toString();
+
+    Json::Value spendData;
+    spendData["signature"] = crypto.sign(out.getId().toString() + outputSetId);
+
+    CryptoKernel::Blockchain::input inp(out.getId(), spendData);
+    CryptoKernel::Blockchain::transaction tx({inp}, {contractOutput}, 1530888581);
+
+    const auto res = blockchain->submitTransaction(tx);
+    CPPUNIT_ASSERT_MESSAGE("Initial contract transaction failed", std::get<0>(res));
+
+    consensus->mineBlock(true, ECDSAPubKey);
+
+    // Try spending from the contract output back to our key. Should fail as the script is just 'return false'
+    Json::Value p2pkOutData;
+    p2pkOutData["publicKey"] = crypto.getPublicKey();
+    CryptoKernel::Blockchain::output p2pkout(contractOutput.getValue() - 40000, 0, p2pkOutData);
+
+    Json::Value spendData2; // empty
+    CryptoKernel::Blockchain::input contractin(contractOutput.getId(), spendData2);
+    CryptoKernel::Blockchain::transaction contractspendtx({contractin}, {p2pkout}, 1530888581);
+
+    std::tuple<bool, bool> res2;
+    CPPUNIT_ASSERT_NO_THROW_MESSAGE("Spending contract caused an exception", res2 = blockchain->submitTransaction(contractspendtx));
+    CPPUNIT_ASSERT_MESSAGE("Spending contract output succeeded. Shouldn't have.", !std::get<0>(res2));
 }

--- a/tests/ContractTests.h
+++ b/tests/ContractTests.h
@@ -14,6 +14,9 @@ class ContractTest : public CPPUNIT_NS::TestFixture {
     CPPUNIT_TEST(testTwoContractInputs);
     CPPUNIT_TEST(testToString);
     CPPUNIT_TEST(testTableIterationOrder);
+    CPPUNIT_TEST(testSimpleError);
+    CPPUNIT_TEST(testMemoryLimit);
+    CPPUNIT_TEST(testInstructionLimit);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -37,6 +40,9 @@ private:
     void testTwoContractInputs();
     void testToString();
     void testTableIterationOrder();
+    void testSimpleError();
+    void testMemoryLimit();
+    void testInstructionLimit();
 
     std::unique_ptr<CryptoKernel::Blockchain> blockchain;
     std::unique_ptr<CryptoKernel::Log> log;


### PR DESCRIPTION
If a Lua script was being validated and exceeded the allowed memory the allocator would throw an exception causing `ckd` to crash. This PR catches the exception so the script validation function returns `false` which is the expected behaviour. Also add some unit tests to ensure the correct behaviour in the event of script execution errors. 