### PR TITLE
Catch InvalidElementException when generating a new mining block

### DIFF
--- a/src/kernel/blockchain.cpp
+++ b/src/kernel/blockchain.cpp
@@ -833,7 +833,7 @@ CryptoKernel::Blockchain::block CryptoKernel::Blockchain::generateVerifyingBlock
     const std::string& publicKey) {
     std::unique_ptr<Storage::Transaction> dbTx(blockdb->beginReadOnly());
 
-    const std::set<transaction> blockTransactions = getUnconfirmedTransactions();
+    std::set<transaction> blockTransactions = getUnconfirmedTransactions();
 
     uint64_t height;
     BigNum previousBlockId;
@@ -856,9 +856,10 @@ CryptoKernel::Blockchain::block CryptoKernel::Blockchain::generateVerifyingBlock
             value += calculateTransactionFee(dbTx.get(), tx);
         } catch(const CryptoKernel::Blockchain::InvalidElementException& e) {
             // rare case: the mempool was rescanned and some txs we have are now invalid.
-            // For now just try again. In the future the mempool should be in the database
-            // so the mempool and current unspent state are always consistent.
-            return generateVerifyingBlock(publicKey);
+            // For now just return an empty block. In the future the mempool should be in 
+            // the database so the mempool and current unspent state are always consistent.
+            blockTransactions.clear();
+            break;
         }
     }
 


### PR DESCRIPTION
Because the mempool is not saved in the database, it can become inconsistent with the current state of the UTXO set. In this case, calculating the transaction fees can cause an exception to be thrown as some of the transaction in our unconfirmed set become invalid and their inputs are removed from the database. As a workaround, simply return a block with no transactions in it.